### PR TITLE
39 add logging integration to mvp

### DIFF
--- a/.idea/runConfigurations/Run_simple.xml
+++ b/.idea/runConfigurations/Run_simple.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run simple" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package ecs --example simple" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <option name="emulateTerminal" value="false" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs>
+      <env name="RUST_LOG" value="info" />
+    </envs>
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Test_all.xml
+++ b/.idea/runConfigurations/Test_all.xml
@@ -2,14 +2,16 @@
   <configuration default="false" name="Test all" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="command" value="test" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <option name="emulateTerminal" value="false" />
     <option name="channel" value="DEFAULT" />
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
-    <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
-    <envs />
+    <envs>
+      <env name="RUST_LOG" value="debug" />
+    </envs>
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "proptest",
  "test-case",
  "test-strategy",
+ "thiserror",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
@@ -1011,6 +1012,26 @@ name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
+name = "thiserror"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +48,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bit-set"
@@ -72,6 +102,12 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -125,6 +161,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -235,6 +298,7 @@ name = "ecs"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "color-eyre",
  "criterion",
  "crossbeam",
  "ntest",
@@ -242,6 +306,9 @@ dependencies = [
  "proptest",
  "test-case",
  "test-strategy",
+ "tracing",
+ "tracing-error",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -249,6 +316,16 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
 
 [[package]]
 name = "fastrand"
@@ -275,6 +352,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "half"
@@ -305,6 +388,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -371,6 +460,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +481,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -419,6 +526,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +552,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -456,10 +582,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plotters"
@@ -659,6 +803,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +825,12 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rusty-fork"
@@ -736,6 +895,21 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "structmeta"
@@ -839,6 +1013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,10 +1050,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "paste",
  "proptest",
  "test-case",
+ "test-log",
  "test-strategy",
  "thiserror",
  "tracing",
@@ -993,6 +994,17 @@ dependencies = [
  "quote",
  "syn",
  "test-case-core",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "test-log",
  "test-strategy",
  "thiserror",
+ "time",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
@@ -553,6 +554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -1056,6 +1066,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1188,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ crossbeam = "0.8"     # Useful concurrency primitives
 paste = "1.0"         # Allows type names to be composed in macros
 test-case = "3.0"     # For parameterized tests
 ntest = "0.9"         # To set timeouts on tests
+tracing = "0.1"       # Configurable logging with different log-levels
+color-eyre = "0.6"    # Pretty-printed error logging and tracing
+tracing-subscriber = { version = "0.3", features = ["env-filter"] } # Tools for composing subscribers (to collect tracing data)
+tracing-error = "0.2" # Enriches error handling with tracing diagnostic information

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ test-case = "3.0"     # For parameterized tests
 ntest = "0.9"         # To set timeouts on tests
 tracing = "0.1"       # Configurable logging with different log-levels
 color-eyre = "0.6"    # Pretty-printed error logging and tracing
-tracing-subscriber = { version = "0.3", features = ["env-filter"] } # Tools for composing subscribers (to collect tracing data)
+tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] } # Tools for composing subscribers (to collect tracing data)
 tracing-error = "0.2" # Enriches error handling with tracing diagnostic information
 test-log = { version = "0.2", default-features = false, features = ["trace"] } # Enables tracing logs to be printed inside tests
 thiserror = "1.0"     # Macros for generating error enums/structs
+time = { version = "0.3", features = ["local-offset"] } # Time-related functions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ tracing = "0.1"       # Configurable logging with different log-levels
 color-eyre = "0.6"    # Pretty-printed error logging and tracing
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } # Tools for composing subscribers (to collect tracing data)
 tracing-error = "0.2" # Enriches error handling with tracing diagnostic information
+thiserror = "1.0"     # Macros for generating error enums/structs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ tracing = "0.1"       # Configurable logging with different log-levels
 color-eyre = "0.6"    # Pretty-printed error logging and tracing
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } # Tools for composing subscribers (to collect tracing data)
 tracing-error = "0.2" # Enriches error handling with tracing diagnostic information
+test-log = { version = "0.2", default-features = false, features = ["trace"] } # Enables tracing logs to be printed inside tests
 thiserror = "1.0"     # Macros for generating error enums/structs

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -11,6 +11,10 @@ bench = false # Disable ordinary libtest benchmark harness since we're running c
 [dependencies]
 crossbeam = { workspace = true }        # Useful concurrency primitives
 paste = { workspace = true }            # Allows type names to be composed in macros
+tracing = { workspace = true }          # Configurable logging with different log-levels
+tracing-subscriber = { workspace = true } # Tools for composing subscribers (to collect tracing data)
+tracing-error = { workspace = true }    # Enriches error handling with tracing diagnostic information
+color-eyre = { workspace = true }       # Pretty-printed error logging and tracing
 
 [dev-dependencies]
 criterion = { workspace = true }        # For benchmarking

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -15,6 +15,7 @@ tracing = { workspace = true }          # Configurable logging with different lo
 tracing-subscriber = { workspace = true } # Tools for composing subscribers (to collect tracing data)
 tracing-error = { workspace = true }    # Enriches error handling with tracing diagnostic information
 color-eyre = { workspace = true }       # Pretty-printed error logging and tracing
+thiserror = { workspace = true }        # Macros for generating error enums/structs
 
 [dev-dependencies]
 criterion = { workspace = true }        # For benchmarking

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -24,6 +24,7 @@ test-strategy = { workspace = true }    # Prop-test macros that are more ergonom
 approx = { workspace = true }           # For approximate floating-point comparisons
 test-case = { workspace = true }        # For parameterized tests
 ntest = { workspace = true }            # To set timeouts on tests
+test-log = { workspace = true }         # Enables tracing logs to be printed inside tests
 
 [[bench]]
 name = "example"

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -16,6 +16,7 @@ tracing-subscriber = { workspace = true } # Tools for composing subscribers (to 
 tracing-error = { workspace = true }    # Enriches error handling with tracing diagnostic information
 color-eyre = { workspace = true }       # Pretty-printed error logging and tracing
 thiserror = { workspace = true }        # Macros for generating error enums/structs
+time = { workspace = true }             # Time-related functions
 
 [dev-dependencies]
 criterion = { workspace = true }        # For benchmarking

--- a/crates/ecs/examples/simple.rs
+++ b/crates/ecs/examples/simple.rs
@@ -1,6 +1,6 @@
 use crossbeam::channel::unbounded;
 use ecs::{Application, Read, Sequential, Unordered, Write};
-use tracing::{info, instrument};
+use tracing::{error, info, instrument, trace, warn};
 
 // a simple example of how to use the crate `ecs`
 #[instrument]
@@ -42,12 +42,19 @@ struct E;
 
 #[instrument]
 fn basic_system() {
+    trace!("very detailed message that is not normally shown");
     info!("no parameters!");
 }
 
 #[instrument]
-fn read_a_system(_: Read<A>) {
-    info!("executing read_a_system")
+fn read_a_system(a: Read<A>) {
+    info!("executing read_a_system");
+    if a.0 > 100_000 {
+        warn!("{a:?} is very big!")
+    }
+    if a.0 == i32::MAX {
+        error!("{a:?} is way too big!")
+    }
 }
 
 #[instrument]

--- a/crates/ecs/examples/simple.rs
+++ b/crates/ecs/examples/simple.rs
@@ -1,9 +1,12 @@
 use crossbeam::channel::unbounded;
 use ecs::{Application, Read, Sequential, Unordered, Write};
+use tracing::{info, instrument};
 
 // a simple example of how to use the crate `ecs`
+#[instrument]
 fn main() {
     let mut app = Application::default()
+        .with_tracing()
         .add_system(basic_system)
         .add_system(read_a_system)
         .add_system(write_a_system)
@@ -37,20 +40,24 @@ struct D;
 #[derive(Debug)]
 struct E;
 
+#[instrument]
 fn basic_system() {
-    println!("basic!");
+    info!("no parameters!");
 }
 
-fn read_a_system(a: Read<A>) {
-    println!("{:?}", a)
+#[instrument]
+fn read_a_system(_: Read<A>) {
+    info!("executing read_a_system")
 }
 
+#[instrument]
 fn write_a_system(mut a: Write<A>) {
     a.0 += 1;
-    println!("{:?}", a)
+    info!("executing write_a_system")
 }
 
-fn read_write_many(mut a: Write<A>, b: Read<B>, c: Write<C>, d: Read<D>, e: Read<E>) {
+#[instrument]
+fn read_write_many(mut a: Write<A>, b: Read<B>, _: Write<C>, _: Read<D>, _: Read<E>) {
     a.0 += b.0;
-    println!("{a:?}, {b:?}, {c:?}, {d:?}, {e:?}")
+    info!("executing read_write_many")
 }

--- a/crates/ecs/examples/simple.rs
+++ b/crates/ecs/examples/simple.rs
@@ -1,12 +1,13 @@
+use color_eyre::Report;
 use crossbeam::channel::unbounded;
 use ecs::{Application, Read, Sequential, Unordered, Write};
 use tracing::{error, info, instrument, trace, warn};
 
 // a simple example of how to use the crate `ecs`
 #[instrument]
-fn main() {
+fn main() -> Result<(), Report> {
     let mut app = Application::default()
-        .with_tracing()
+        .with_tracing()?
         .add_system(basic_system)
         .add_system(read_a_system)
         .add_system(write_a_system)
@@ -23,6 +24,8 @@ fn main() {
 
     let (_shutdown_sender, shutdown_receiver) = unbounded();
     app.run::<Sequential, Unordered>(shutdown_receiver);
+
+    Ok(())
 }
 
 #[derive(Debug)]

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -27,6 +27,8 @@
     clippy::large_enum_variant
 )]
 
+pub mod logging;
+
 use crossbeam::channel::{Receiver, TryRecvError};
 use paste::paste;
 use std::any::{Any, TypeId};

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -38,6 +38,7 @@ use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard, TryLockError};
 use std::{any, fmt};
+use tracing::instrument;
 
 /// The entry-point of the entire program, containing all of the entities, components and systems.
 #[derive(Default, Debug)]
@@ -324,6 +325,7 @@ where
     Function: SystemParameterFunction<Parameters> + Send + Sync + 'static,
     Parameters: SystemParameters,
 {
+    #[instrument(skip_all)]
     fn run(&self, world: &World) {
         SystemParameterFunction::run(&self.function, world);
     }

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -539,6 +539,7 @@ impl_system_parameter_function!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
 mod tests {
     use super::*;
     use test_case::test_case;
+    use test_log::test;
 
     #[derive(Debug)]
     struct A;

--- a/crates/ecs/src/logging.rs
+++ b/crates/ecs/src/logging.rs
@@ -1,30 +1,48 @@
 //! An add-on to `ecs::Application` that provides sophisticated and configurable
 //! logging using `tracing`.
 
+use crate::logging::LoggingError::{ColorInitialization, Configuration};
 use crate::Application;
+use thiserror::Error;
+
+/// An error that occurred when setting up logging.
+#[derive(Error, Debug)]
+pub enum LoggingError {
+    /// Could not initialize coloring of logs.
+    #[error("could not initialize coloring of logs")]
+    ColorInitialization(#[source] color_eyre::Report),
+    /// Failed to load logging configuration.
+    #[error("failed to load logging configuration")]
+    Configuration(#[source] tracing_subscriber::filter::ParseError),
+}
+
+/// Whether a logging operation succeeded.
+pub type LoggingResult<T, E = LoggingError> = Result<T, E>;
 
 impl Application {
     /// Attaches and initializes tracing infrastructure.
-    pub fn with_tracing(self) -> Self {
-        install_tracing();
-        color_eyre::install().expect("todo: error handling");
-        self
+    pub fn with_tracing(self) -> LoggingResult<Self> {
+        install_tracing()?;
+        color_eyre::install().map_err(ColorInitialization)?;
+        Ok(self)
     }
 }
 
-fn install_tracing() {
+fn install_tracing() -> LoggingResult<()> {
     use tracing_error::ErrorLayer;
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{fmt, EnvFilter};
 
     let fmt_layer = fmt::layer().with_thread_ids(true).with_target(false);
     let filter_layer = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new("warn"))
-        .expect("todo: error handling");
+        .or_else(|_| EnvFilter::try_new("warn")) // Default to only warnings.
+        .map_err(Configuration)?;
 
     tracing_subscriber::registry()
         .with(filter_layer)
         .with(fmt_layer)
         .with(ErrorLayer::default())
         .init();
+
+    Ok(())
 }

--- a/crates/ecs/src/logging.rs
+++ b/crates/ecs/src/logging.rs
@@ -1,0 +1,30 @@
+//! An add-on to `ecs::Application` that provides sophisticated and configurable
+//! logging using `tracing`.
+
+use crate::Application;
+
+impl Application {
+    /// Attaches and initializes tracing infrastructure.
+    pub fn with_tracing(self) -> Self {
+        install_tracing();
+        color_eyre::install().expect("todo: error handling");
+        self
+    }
+}
+
+fn install_tracing() {
+    use tracing_error::ErrorLayer;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let fmt_layer = fmt::layer().with_thread_ids(true).with_target(false);
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("warn"))
+        .expect("todo: error handling");
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .with(ErrorLayer::default())
+        .init();
+}

--- a/crates/ecs/tests/application_tests.rs
+++ b/crates/ecs/tests/application_tests.rs
@@ -4,6 +4,8 @@ use ntest::timeout;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{Arc, Mutex};
+//noinspection RsUnusedImport -- For some reason CLion can't detect that it's being used.
+use test_log::test;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 struct A;


### PR DESCRIPTION
Adds pretty logging infrastructure. 

Some screenshots of various scenarios:

### Normal logging
Here the logging level is set to `info`

![clion64_apaix5wWGN](https://user-images.githubusercontent.com/12572888/224487838-2ffca121-ef8f-4676-9266-ea36f36f8fbf.png)

Note that you can log debug messages using syntax like:
```rust
debug!(message = "this is some debug info", ?some_variable_name);
```

### A panic occurs
![clion64_rSg9MmwE0O](https://user-images.githubusercontent.com/12572888/224487859-1c5f1171-931a-4efb-895e-0d8f35556895.png)

### A panic within a span occurs
The neat thing here is the `spantrace` which shows all functions (instrumented with `#[instrument]`) and what parameter values they were called with to cause this panic/error.

![image](https://user-images.githubusercontent.com/12572888/224488370-e048b31e-5c00-4edd-9fe9-515bb3fd103d.png)


### Nested errors occur
(This also demonstrates why handling errors using the manner shown in `ecs::logging` in this PR is optimal!)

![clion64_Z0qVyvFKPl](https://user-images.githubusercontent.com/12572888/224488106-32bcdc6c-0705-4bbc-91cb-17f93ef30753.png)

Here's how the error declarations in the example above were written:
```rust
#[derive(Error, Debug)]
pub enum OuterError {
    #[error("this adds context about what the caller was trying to achieve")]
    Test(#[source] InnerError),
}

#[derive(Error, Debug)]
pub enum InnerError {
    #[error("this is what originally caused the error, with data: {0}")]
    Test(i32),
}
```

Closes #39 
