### PR TITLE
40 integrate with tracy profiling tool

### DIFF
--- a/.idea/runConfigurations/Run_parallel__with_profiling_.xml
+++ b/.idea/runConfigurations/Run_parallel__with_profiling_.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run parallel (with profiling)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package scheduler --example parallel --release --features profile" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <option name="emulateTerminal" value="false" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs>
+      <env name="RUST_LOG" value="info" />
+    </envs>
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "tracing-tracy",
 ]
 
 [[package]]
@@ -362,6 +363,19 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generator"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a20a288a94683f5f4da0adecdbe095c94a77c295e514cc6484e9394dd8376e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
 
 [[package]]
 name = "getrandom"
@@ -478,6 +492,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -882,6 +909,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,7 +963,14 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "tracy-client",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1264,6 +1304,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-tracy"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c48ef3e655220d4e43a6be44aa84f078c3004357251cab45f9cc15551a593e"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracy-client",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d99f5fc382239d08b6bf05bb6206a585bfdb988c878f2499081d0f285ef7819"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1472,72 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ test-case = "3.0"     # For parameterized tests
 ntest = "0.9"         # To set timeouts on tests
 tracing = "0.1"       # Configurable logging with different log-levels
 color-eyre = "0.6"    # Pretty-printed error logging and tracing
-tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] } # Tools for composing subscribers (to collect tracing data)
+tracing-subscriber = { version = "0.3", features = ["env-filter", "time", "registry"] } # Tools for composing subscribers (to collect tracing data)
 tracing-error = "0.2" # Enriches error handling with tracing diagnostic information
 test-log = { version = "0.2", default-features = false, features = ["trace"] } # Enables tracing logs to be printed inside tests
 thiserror = "1.0"     # Macros for generating error enums/structs
@@ -30,3 +30,5 @@ time = { version = "0.3", features = ["local-offset"] } # Time-related functions
 rand = "0.8"          # Random number generation
 num_cpus = "1.15"     # To get the current number of logical/physical cores
 daggy = "0.8"         # Directed Acyclic Graphs (DAGs)
+tracing-tracy = "0.10"# Integration with Tracy profiling tool
+tracy-client = "0.15"     # Integration with Tracy profiling tool

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,5 @@ time = { version = "0.3", features = ["local-offset"] } # Time-related functions
 rand = "0.8"          # Random number generation
 num_cpus = "1.15"     # To get the current number of logical/physical cores
 daggy = "0.8"         # Directed Acyclic Graphs (DAGs)
-tracing-tracy = "0.10"# Integration with Tracy profiling tool
-tracy-client = "0.15"     # Integration with Tracy profiling tool
+tracing-tracy = "0.10"# Tracing integration with Tracy
+tracy-client = "0.15" # Direct integration with Tracy profiling tool

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [lib]
 bench = false # Disable ordinary libtest benchmark harness since we're running criterion
 
+[features]
+profile = []                            # Enables profiling with Tracy
+
 [dependencies]
 crossbeam = { workspace = true }        # Useful concurrency primitives
 paste = { workspace = true }            # Allows type names to be composed in macros
@@ -18,6 +21,7 @@ color-eyre = { workspace = true }       # Pretty-printed error logging and traci
 thiserror = { workspace = true }        # Macros for generating error enums/structs
 itertools = { workspace = true }        # Iterator helper functions
 time = { workspace = true }             # Time-related functions
+tracing-tracy = { workspace = true }    # Integration with Tracy profiling tool
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -21,7 +21,7 @@ color-eyre = { workspace = true }       # Pretty-printed error logging and traci
 thiserror = { workspace = true }        # Macros for generating error enums/structs
 itertools = { workspace = true }        # Iterator helper functions
 time = { workspace = true }             # Time-related functions
-tracing-tracy = { workspace = true }    # Integration with Tracy profiling tool
+tracing-tracy = { workspace = true }    # Tracing integration with Tracy
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -28,6 +28,7 @@
 )]
 
 pub mod logging;
+mod profiling;
 
 use crate::ApplicationError::ScheduleGeneration;
 use crossbeam::channel::{bounded, Receiver, Sender, TryRecvError};

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -489,10 +489,10 @@ impl<Function: Send + Sync, Parameters: SystemParameters> Debug
             parameter_names_text.push_str(parameter_name);
         }
 
-        writeln!(f, "FunctionSystem {{")?;
-        writeln!(f, "    system = {}", &self.function_name)?;
-        writeln!(f, "    parameters = {parameter_names_text}")?;
-        writeln!(f, "}}")
+        f.debug_struct("FunctionSystem")
+            .field("system", &self.function_name)
+            .field("parameters", &parameter_names_text)
+            .finish()
     }
 }
 

--- a/crates/ecs/src/logging.rs
+++ b/crates/ecs/src/logging.rs
@@ -6,7 +6,11 @@ use crate::Application;
 use thiserror::Error;
 use time::format_description::well_known::Iso8601;
 use time::UtcOffset;
+use tracing_error::ErrorLayer;
+use tracing_subscriber::fmt;
 use tracing_subscriber::fmt::time::OffsetTime;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
 
 /// An error that occurred when setting up logging.
 #[derive(Error, Debug)]
@@ -32,10 +36,6 @@ impl Application {
 }
 
 fn install_tracing() -> LoggingResult<()> {
-    use tracing_error::ErrorLayer;
-    use tracing_subscriber::prelude::*;
-    use tracing_subscriber::{fmt, EnvFilter};
-
     // In some environments it's not possible to get current local time zone offset without
     // invoking undefined behavior, so it might fail -- in which case we just use UTC.
     let offset = match UtcOffset::current_local_offset() {

--- a/crates/ecs/src/profiling.rs
+++ b/crates/ecs/src/profiling.rs
@@ -1,0 +1,21 @@
+//! An add-on to `ecs::Application` that enables profiling using the
+//! [Tracy profiling tool](https://github.com/wolfpld/tracy).
+
+use crate::Application;
+use tracing::metadata::LevelFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::prelude::*;
+
+impl Application {
+    /// Enables profiling connection to Tracy.
+    #[allow(clippy::print_stdout)] // Because we can't print to console using tracing when it's disabled
+    pub fn with_profiling(self) -> Self {
+        tracing_subscriber::registry()
+            .with(tracing_tracy::TracyLayer::new().with_filter(LevelFilter::INFO))
+            .init();
+
+        println!("running with profiling enabled!");
+        println!("this means console output will be limited in favor of performance");
+        self
+    }
+}

--- a/crates/ecs/src/profiling.rs
+++ b/crates/ecs/src/profiling.rs
@@ -16,7 +16,7 @@ pub enum ProfilingError {
     GlobalSubscriber(#[source] tracing_subscriber::util::TryInitError),
 }
 
-/// Whether a logging operation succeeded.
+/// Whether a profiling operation succeeded.
 pub type ProfilingResult<T, E = ProfilingError> = Result<T, E>;
 
 impl Application {

--- a/crates/ecs/src/profiling.rs
+++ b/crates/ecs/src/profiling.rs
@@ -24,7 +24,7 @@ impl Application {
     #[allow(clippy::print_stdout)] // Because we can't print to console using tracing when it's disabled
     pub fn with_profiling(self) -> ProfilingResult<Self> {
         tracing_subscriber::registry()
-            .with(tracing_tracy::TracyLayer::new().with_filter(LevelFilter::INFO))
+            .with(tracing_tracy::TracyLayer::new().with_filter(LevelFilter::TRACE))
             .try_init()
             .map_err(GlobalSubscriber)?;
 

--- a/crates/ecs/src/profiling.rs
+++ b/crates/ecs/src/profiling.rs
@@ -1,21 +1,35 @@
 //! An add-on to `ecs::Application` that enables profiling using the
 //! [Tracy profiling tool](https://github.com/wolfpld/tracy).
 
+use crate::profiling::ProfilingError::GlobalSubscriber;
 use crate::Application;
+use thiserror::Error;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::prelude::*;
 
+/// An error that occurred when setting up profiling.
+#[derive(Error, Debug)]
+pub enum ProfilingError {
+    /// Failed to set up profiling trace subscriber.
+    #[error("failed to set up profiling trace subscriber")]
+    GlobalSubscriber(#[source] tracing_subscriber::util::TryInitError),
+}
+
+/// Whether a logging operation succeeded.
+pub type ProfilingResult<T, E = ProfilingError> = Result<T, E>;
+
 impl Application {
     /// Enables profiling connection to Tracy.
     #[allow(clippy::print_stdout)] // Because we can't print to console using tracing when it's disabled
-    pub fn with_profiling(self) -> Self {
+    pub fn with_profiling(self) -> ProfilingResult<Self> {
         tracing_subscriber::registry()
             .with(tracing_tracy::TracyLayer::new().with_filter(LevelFilter::INFO))
-            .init();
+            .try_init()
+            .map_err(GlobalSubscriber)?;
 
         println!("running with profiling enabled!");
         println!("this means console output will be limited in favor of performance");
-        self
+        Ok(self)
     }
 }

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = { workspace = true }        # Macros for generating error enums/stru
 num_cpus = { workspace = true }         # To get the current number of logical/physical cores
 itertools = { workspace = true }        # Iterator helper functions
 daggy = { workspace = true }            # Directed Acyclic Graphs (DAGs)
-tracy-client = { workspace = true }     # Integration with Tracy profiling tool
+tracy-client = { workspace = true }     # Direct integration with Tracy profiling tool
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [lib]
 bench = false # Disable ordinary libtest benchmark harness since we're running criterion
 
+[features]
+profile = ["ecs/profile"]               # 'profile' feature is enabled if it's enabled in ecs crate
+
 [dependencies]
 ecs = { path = "../ecs" }
 crossbeam = { workspace = true }        # Useful concurrency primitives
@@ -16,6 +19,7 @@ thiserror = { workspace = true }        # Macros for generating error enums/stru
 num_cpus = { workspace = true }         # To get the current number of logical/physical cores
 itertools = { workspace = true }        # Iterator helper functions
 daggy = { workspace = true }            # Directed Acyclic Graphs (DAGs)
+tracy-client = { workspace = true }     # Integration with Tracy profiling tool
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/scheduler/examples/parallel.rs
+++ b/crates/scheduler/examples/parallel.rs
@@ -47,13 +47,13 @@ struct D;
 struct E;
 
 #[instrument]
-#[inline(never)]
+#[cfg_attr(feature = "profile", inline(never))]
 fn basic_system() {
     info!("no parameters!");
 }
 
 #[instrument]
-#[inline(never)]
+#[cfg_attr(feature = "profile", inline(never))]
 fn read_b_system(b: Read<B>) {
     info!("executing");
     if b.0 > 100_000 {
@@ -65,14 +65,14 @@ fn read_b_system(b: Read<B>) {
 }
 
 #[instrument]
-#[inline(never)]
+#[cfg_attr(feature = "profile", inline(never))]
 fn write_b_system(mut b: Write<B>) {
     b.0 += 1;
     info!("executing");
 }
 
 #[instrument]
-#[inline(never)]
+#[cfg_attr(feature = "profile", inline(never))]
 fn read_write_many(mut a: Write<A>, b: Read<B>, _: Write<C>, _: Read<D>, _: Read<E>) {
     a.0 += b.0;
     info!("executing");

--- a/crates/scheduler/examples/parallel.rs
+++ b/crates/scheduler/examples/parallel.rs
@@ -3,9 +3,7 @@ use crossbeam::channel::unbounded;
 use ecs::{Application, Read, Write};
 use scheduler::executor::WorkerPool;
 use scheduler::schedule::PrecedenceGraph;
-use std::thread;
-use std::time::Duration;
-use tracing::{error, info, instrument, trace, warn};
+use tracing::{error, info, instrument, warn};
 
 // a simple example of how to use the crate `ecs`
 #[instrument]
@@ -49,9 +47,7 @@ struct E;
 
 #[instrument]
 fn basic_system() {
-    trace!("very detailed message that is not normally shown");
     info!("no parameters!");
-    thread::sleep(Duration::from_nanos(10));
 }
 
 #[instrument]
@@ -63,19 +59,16 @@ fn read_b_system(b: Read<B>) {
     if b.0 == i32::MAX {
         error!("{b:?} is way too big!")
     }
-    thread::sleep(Duration::from_nanos(10));
 }
 
 #[instrument]
 fn write_b_system(mut b: Write<B>) {
     b.0 += 1;
     info!("executing");
-    thread::sleep(Duration::from_nanos(10));
 }
 
 #[instrument]
 fn read_write_many(mut a: Write<A>, b: Read<B>, _: Write<C>, _: Read<D>, _: Read<E>) {
     a.0 += b.0;
     info!("executing");
-    thread::sleep(Duration::from_nanos(10));
 }

--- a/crates/scheduler/examples/parallel.rs
+++ b/crates/scheduler/examples/parallel.rs
@@ -10,7 +10,6 @@ use tracing::{error, info, instrument, warn};
 fn main() -> Result<(), Report> {
     let mut app = Application::default()
         .with_tracing()?
-        .with_profiling()?
         .add_system(basic_system)
         .add_system(read_b_system)
         .add_system(write_b_system)

--- a/crates/scheduler/examples/parallel.rs
+++ b/crates/scheduler/examples/parallel.rs
@@ -9,7 +9,8 @@ use tracing::{error, info, instrument, warn};
 #[instrument]
 fn main() -> Result<(), Report> {
     let mut app = Application::default()
-        .with_tracing()?
+        //.with_tracing()?
+        .with_profiling()?
         .add_system(basic_system)
         .add_system(read_b_system)
         .add_system(write_b_system)
@@ -46,11 +47,13 @@ struct D;
 struct E;
 
 #[instrument]
+#[inline(never)]
 fn basic_system() {
     info!("no parameters!");
 }
 
 #[instrument]
+#[inline(never)]
 fn read_b_system(b: Read<B>) {
     info!("executing");
     if b.0 > 100_000 {
@@ -62,12 +65,14 @@ fn read_b_system(b: Read<B>) {
 }
 
 #[instrument]
+#[inline(never)]
 fn write_b_system(mut b: Write<B>) {
     b.0 += 1;
     info!("executing");
 }
 
 #[instrument]
+#[inline(never)]
 fn read_write_many(mut a: Write<A>, b: Read<B>, _: Write<C>, _: Read<D>, _: Read<E>) {
     a.0 += b.0;
     info!("executing");

--- a/crates/scheduler/examples/parallel.rs
+++ b/crates/scheduler/examples/parallel.rs
@@ -9,8 +9,7 @@ use tracing::{error, info, instrument, warn};
 #[instrument]
 fn main() -> Result<(), Report> {
     let mut app = Application::default()
-        //.with_tracing()?
-        .with_profiling()?
+        .with_tracing()?
         .add_system(basic_system)
         .add_system(read_b_system)
         .add_system(write_b_system)

--- a/crates/scheduler/src/executor/mod.rs
+++ b/crates/scheduler/src/executor/mod.rs
@@ -87,7 +87,7 @@ impl<'task> WorkerPool<'task> {
 }
 
 impl<'systems> Executor<'systems> for WorkerPool<'systems> {
-    #[tracing::instrument(skip(self, world, shutdown_receiver))]
+    #[tracing::instrument(skip_all)]
     fn execute<S: Schedule<'systems>>(
         &mut self,
         mut schedule: S,

--- a/crates/scheduler/src/executor/mod.rs
+++ b/crates/scheduler/src/executor/mod.rs
@@ -68,14 +68,14 @@ pub struct WorkerPool<'task> {
 }
 
 impl<'task> WorkerPool<'task> {
-    #[tracing::instrument]
+    #[tracing::instrument(skip(self))]
     fn add_task(&mut self, task: Task<'task>) {
         self.global_queue.push(task);
         self.notify_all_workers();
     }
 
     /// Wakes up all the workers, if they were sleeping.
-    #[tracing::instrument]
+    #[tracing::instrument(skip(self))]
     fn notify_all_workers(&self) {
         for unparker in &self.worker_unparkers {
             // It's okay that this might be called on an already-awake worker,
@@ -87,7 +87,7 @@ impl<'task> WorkerPool<'task> {
 }
 
 impl<'systems> Executor<'systems> for WorkerPool<'systems> {
-    #[tracing::instrument]
+    #[tracing::instrument(skip(self, world, shutdown_receiver))]
     fn execute<S: Schedule<'systems>>(
         &mut self,
         mut schedule: S,

--- a/crates/scheduler/src/executor/mod.rs
+++ b/crates/scheduler/src/executor/mod.rs
@@ -22,7 +22,7 @@ struct Task<'a> {
 
 impl<'a> std::fmt::Debug for Task<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Task<{}>", self.uid)
+        f.debug_struct("Task").field("uid", &self.uid).finish()
     }
 }
 

--- a/crates/scheduler/src/schedule/mod.rs
+++ b/crates/scheduler/src/schedule/mod.rs
@@ -19,7 +19,7 @@ use ecs::{Schedule, ScheduleError, ScheduleResult, System, SystemExecutionGuard}
 use itertools::Itertools;
 use std::fmt::{Debug, Display, Formatter};
 use thiserror::Error;
-use tracing::{debug, error};
+use tracing::{debug, error, instrument};
 
 type Sys<'system> = &'system dyn System;
 type SysDag<'system> = Dag<Sys<'system>, i32>;
@@ -98,6 +98,8 @@ impl<'systems> PartialEq<Self> for PrecedenceGraph<'systems> {
 }
 
 impl<'systems> Schedule<'systems> for PrecedenceGraph<'systems> {
+    #[instrument]
+    #[inline(never)]
     fn generate(systems: &'systems [Box<dyn System>]) -> ScheduleResult<Self> {
         let mut dag = Dag::new();
 
@@ -142,6 +144,8 @@ fn into_next_systems_error(internal_error: PrecedenceGraphError) -> ScheduleErro
 impl<'systems> PrecedenceGraph<'systems> {
     /// Blocks until enough pending systems have executed that
     /// at least one new system is able to execute.
+    #[instrument(skip(self))]
+    #[inline(never)]
     fn get_next_systems_to_run(
         &mut self,
     ) -> PrecedenceGraphResult<Vec<SystemExecutionGuard<'systems>>> {

--- a/crates/scheduler/src/schedule/mod.rs
+++ b/crates/scheduler/src/schedule/mod.rs
@@ -99,7 +99,7 @@ impl<'systems> PartialEq<Self> for PrecedenceGraph<'systems> {
 
 impl<'systems> Schedule<'systems> for PrecedenceGraph<'systems> {
     #[instrument]
-    #[inline(never)]
+    #[cfg_attr(feature = "profile", inline(never))]
     fn generate(systems: &'systems [Box<dyn System>]) -> ScheduleResult<Self> {
         let mut dag = Dag::new();
 
@@ -145,7 +145,7 @@ impl<'systems> PrecedenceGraph<'systems> {
     /// Blocks until enough pending systems have executed that
     /// at least one new system is able to execute.
     #[instrument(skip(self))]
-    #[inline(never)]
+    #[cfg_attr(feature = "profile", inline(never))]
     fn get_next_systems_to_run(
         &mut self,
     ) -> PrecedenceGraphResult<Vec<SystemExecutionGuard<'systems>>> {

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+bench = false # Disable ordinary libtest benchmark harness since we're running criterion
+
 [dependencies]
 ecs = { path = "../ecs" }
 proptest = { workspace = true }         # Property-based testing tools and harness


### PR DESCRIPTION
Enables profiling integration with the [Tracy profiling tool](https://github.com/wolfpld/tracy).

![image](https://user-images.githubusercontent.com/12572888/226649799-e3a3c7c9-e842-4857-a391-b2060d6522b0.png)

[Demo video](https://i.imgur.com/ELvjZkN.mp4)

Profiling is not enabled by default, but is an optional feature that can be enabled using a compilation flag and a configuration call to `Application`.

When profiling is enabled, no logging to console is done. This is to increase the performance. 

To run the profiler on the `parallel.rs` example in the `scheduler` crate:
1. Switch out the call to `.with_tracing()?` to `with_profiling()?`: 
```rust 
let mut app = Application::default()
        //.with_tracing()?
        .with_profiling()?
```
3. Enable the `profile` feature by adding the compilation flag `--features profile` to the end of the `cargo run` command (either in CLion run configuration, or in terminal).
4. Start Tracy.
5. Run `parallel.rs`.
6. In Tracy, click "Connect".

Closes #40 