### PR TITLE
87 integrate renderer into ecs

### DIFF
--- a/.idea/runConfigurations/Run_rendered_ecs.xml
+++ b/.idea/runConfigurations/Run_rendered_ecs.xml
@@ -10,7 +10,7 @@
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs>
-      <env name="RUST_LOG" value="info,wgpu_core=warn" />
+      <env name="RUST_LOG" value="trace,wgpu_core=warn" />
     </envs>
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />

--- a/.idea/runConfigurations/Run_rendered_ecs.xml
+++ b/.idea/runConfigurations/Run_rendered_ecs.xml
@@ -10,7 +10,7 @@
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs>
-      <env name="RUST_LOG" value="scheduler=debug,ecs=debug,wgpu_core=warn" />
+      <env name="RUST_LOG" value="info,wgpu_core=warn" />
     </envs>
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,6 +1085,7 @@ dependencies = [
  "crossbeam",
  "ecs",
  "gfx",
+ "itertools",
  "ntest",
  "proptest",
  "rand",

--- a/crates/ecs/examples/simple.rs
+++ b/crates/ecs/examples/simple.rs
@@ -2,7 +2,7 @@ use color_eyre::Report;
 use crossbeam::channel::unbounded;
 use ecs::logging::Loggable;
 use ecs::systems::{Read, Write};
-use ecs::{Application, BasicApplication, Sequential, Unordered};
+use ecs::{Application, ApplicationBuilder, BasicApplicationBuilder, Sequential, Unordered};
 use std::thread;
 use std::time::Duration;
 use tracing::{error, info, instrument, trace, warn};
@@ -10,12 +10,13 @@ use tracing::{error, info, instrument, trace, warn};
 // a simple example of how to use the crate `ecs`
 #[instrument]
 fn main() -> Result<(), Report> {
-    let mut app = BasicApplication::default()
+    let mut app = BasicApplicationBuilder::default()
         .with_tracing()?
         .add_system(basic_system)
         .add_system(read_a_system)
         .add_system(write_a_system)
-        .add_system(read_write_many);
+        .add_system(read_write_many)
+        .build();
 
     for i in 0..10 {
         let entity = app.create_entity()?;

--- a/crates/ecs/src/logging.rs
+++ b/crates/ecs/src/logging.rs
@@ -2,7 +2,7 @@
 //! logging using `tracing`.
 
 use crate::logging::LoggingError::{ColorInitialization, Configuration, GlobalSubscriber};
-use crate::Application;
+use crate::ApplicationBuilder;
 use thiserror::Error;
 use time::format_description::well_known::Iso8601;
 use time::UtcOffset;
@@ -29,13 +29,13 @@ pub enum LoggingError {
 /// Whether a logging operation succeeded.
 pub type LoggingResult<T, E = LoggingError> = Result<T, E>;
 
-/// Represents an [`Application`] which can log messages.
+/// Represents an [`ApplicationBuilder`] which can build an [`crate::Application`] which logs messages.
 pub trait Loggable: Sized {
     /// Attaches and initializes tracing infrastructure.
     fn with_tracing(self) -> LoggingResult<Self>;
 }
 
-impl<App: Application> Loggable for App {
+impl<AppBuilder: ApplicationBuilder> Loggable for AppBuilder {
     fn with_tracing(self) -> LoggingResult<Self> {
         install_tracing()?;
         color_eyre::install().map_err(ColorInitialization)?;

--- a/crates/ecs/src/profiling.rs
+++ b/crates/ecs/src/profiling.rs
@@ -2,7 +2,7 @@
 //! [Tracy profiling tool](https://github.com/wolfpld/tracy).
 
 use crate::profiling::ProfilingError::GlobalSubscriber;
-use crate::Application;
+use crate::ApplicationBuilder;
 use thiserror::Error;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -19,13 +19,13 @@ pub enum ProfilingError {
 /// Whether a profiling operation succeeded.
 pub type ProfilingResult<T, E = ProfilingError> = Result<T, E>;
 
-/// Represents an [`Application`] which can be profiled.
+/// Represents an [`ApplicationBuilder`] which can build an [`crate::Application`] which can be profiled.
 pub trait Profileable: Sized {
     /// Enables profiling connection to Tracy.
     fn with_profiling(self) -> ProfilingResult<Self>;
 }
 
-impl<App: Application> Profileable for App {
+impl<AppBuilder: ApplicationBuilder> Profileable for AppBuilder {
     #[allow(clippy::print_stdout)] // Because we can't print to console using tracing when it's disabled
     fn with_profiling(self) -> ProfilingResult<Self> {
         tracing_subscriber::registry()

--- a/crates/ecs/tests/application_tests.rs
+++ b/crates/ecs/tests/application_tests.rs
@@ -1,6 +1,6 @@
 use crossbeam::channel::unbounded;
 use ecs::systems::{Read, Write};
-use ecs::{Application, BasicApplication, Sequential, Unordered};
+use ecs::{Application, ApplicationBuilder, BasicApplicationBuilder, Sequential, Unordered};
 use ntest::timeout;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering::SeqCst;
@@ -34,7 +34,9 @@ fn system_is_passed_component_values_for_each_entity() {
         }
     };
 
-    let mut app = BasicApplication::default().add_system(system);
+    let mut app = BasicApplicationBuilder::default()
+        .add_system(system)
+        .build();
 
     let entity = app.create_entity().unwrap();
     app.add_component(entity, A).unwrap();
@@ -70,9 +72,10 @@ fn system_mutates_component_values() {
         }
     };
 
-    let mut app = BasicApplication::default()
+    let mut app = BasicApplicationBuilder::default()
         .add_system(write_system)
-        .add_system(read_system);
+        .add_system(read_system)
+        .build();
 
     for identifier in 0..expected_component_count {
         let entity = app.create_entity().unwrap();
@@ -117,10 +120,11 @@ fn multiparameter_systems_run_with_component_values_queried() {
         one_parameter_count.fetch_add(1, SeqCst);
     };
 
-    let mut app = BasicApplication::default()
+    let mut app = BasicApplicationBuilder::default()
         .add_system(three_parameter_system)
         .add_system(two_parameter_system)
-        .add_system(one_parameter_system);
+        .add_system(one_parameter_system)
+        .build();
 
     let entity = app.create_entity().unwrap();
     app.add_component(entity, A).unwrap();

--- a/crates/gfx-plugin/Cargo.toml
+++ b/crates/gfx-plugin/Cargo.toml
@@ -17,6 +17,7 @@ gfx = { path = "../gfx" }
 crossbeam = { workspace = true }        # Useful concurrency primitives
 thiserror = { workspace = true }        # Macros for generating error enums/structs
 tracing = { workspace = true }          # Configurable logging with different log-levels
+cgmath = { workspace = true }           # For linear algebra
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }
@@ -30,4 +31,3 @@ ntest = { workspace = true }            # To set timeouts on tests
 test-log = { workspace = true }         # Enables tracing logs to be printed inside tests
 color-eyre = { workspace = true }       # Pretty-printed error logging and tracing
 rand = { workspace = true }             # Random number generation
-cgmath = { workspace = true }       # For linear algebra

--- a/crates/gfx-plugin/Cargo.toml
+++ b/crates/gfx-plugin/Cargo.toml
@@ -18,6 +18,7 @@ crossbeam = { workspace = true }        # Useful concurrency primitives
 thiserror = { workspace = true }        # Macros for generating error enums/structs
 tracing = { workspace = true }          # Configurable logging with different log-levels
 cgmath = { workspace = true }           # For linear algebra
+itertools = { workspace = true }        # Iterator helper functions
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/gfx-plugin/examples/rendered-ecs.rs
+++ b/crates/gfx-plugin/examples/rendered-ecs.rs
@@ -3,7 +3,7 @@ use color_eyre::Report;
 use crossbeam::channel::unbounded;
 use ecs::logging::Loggable;
 use ecs::systems::Write;
-use ecs::{Application, BasicApplication};
+use ecs::{Application, ApplicationBuilder, BasicApplicationBuilder};
 use gfx::Transform;
 use gfx_plugin::Graphical;
 use rand::Rng;
@@ -16,10 +16,11 @@ use tracing::{instrument, warn};
 // a simple example of how to use the crate `ecs`
 #[instrument]
 fn main() -> Result<(), Report> {
-    let mut app = BasicApplication::default()
+    let mut app = BasicApplicationBuilder::default()
         .with_rendering()?
         .with_tracing()?
-        .add_system(movement_system);
+        .add_system(movement_system)
+        .build();
 
     let mut random = rand::thread_rng();
     for _ in 0..10 {

--- a/crates/gfx-plugin/examples/rendered-ecs.rs
+++ b/crates/gfx-plugin/examples/rendered-ecs.rs
@@ -9,8 +9,6 @@ use gfx_plugin::Graphical;
 use rand::Rng;
 use scheduler::executor::WorkerPool;
 use scheduler::schedule::PrecedenceGraph;
-use std::thread;
-use std::time::Duration;
 use tracing::{instrument, warn};
 
 // a simple example of how to use the crate `ecs`
@@ -60,6 +58,5 @@ struct Placement(Transform);
 #[instrument]
 fn movement_system(mut a: Write<Placement>) {
     a.0.position.x += 0.001;
-    thread::sleep(Duration::from_millis(10));
     warn!("i work! {a:#?}");
 }

--- a/crates/gfx-plugin/examples/rendered-ecs.rs
+++ b/crates/gfx-plugin/examples/rendered-ecs.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Report> {
 
     Ok(())
 }
-
+// todo(#90): Take into account for delta time (add delta time as a resource)
 const ROTATION_DELTA: f32 = 1.0;
 
 fn rotation_system(position: Read<Position>, mut rotation: Write<Rotation>) {

--- a/crates/gfx-plugin/src/lib.rs
+++ b/crates/gfx-plugin/src/lib.rs
@@ -28,6 +28,8 @@
     clippy::large_enum_variant
 )]
 
+pub mod rendering;
+
 use crossbeam::channel::Receiver;
 use ecs::systems::{IntoSystem, SystemParameters};
 use ecs::{Application, ApplicationBuilder, Entity, Executor, Schedule};

--- a/crates/gfx-plugin/src/lib.rs
+++ b/crates/gfx-plugin/src/lib.rs
@@ -148,16 +148,15 @@ where
             thread::Builder::new()
                 .name("simulation".to_string())
                 .spawn_scoped(scope, move || {
-                    #[allow(unused)] // todo(#87): use render_data_sender and main_thread_sender
                     let GraphicsEngineHandle {
-                        mut render_data_sender,
+                        render_data_sender,
                         shutdown_receiver,
                         main_thread_sender,
                     } = graphics_engine_handle;
 
-                    // todo(#68): replace with non-closure system which takes as input
-                    // todo(#68): a resource `UpdateRate` and `MainThreadSender` instead of
-                    // todo(#68): using a static and capturing variables like the below implementation.
+                    // todo(#90): replace with non-closure system which takes as input
+                    // todo(#90): a resource `UpdateRate` and `MainThreadSender` instead of
+                    // todo(#90): using a static and capturing variables like the below implementation.
                     let tick_rate_system = move || {
                         const AVERAGE_BUFFER_SIZE: usize = 128;
                         static UPDATE_RATE: Mutex<Option<UpdateRate>> = Mutex::new(None);
@@ -179,6 +178,7 @@ where
                         }
                     };
 
+                    // todo(#90): remove wrapper
                     let rendering_system_wrapper = move |query: RenderQuery| {
                         let render_data_sender = render_data_sender.clone();
                         rendering_system(render_data_sender, query);

--- a/crates/gfx-plugin/src/lib.rs
+++ b/crates/gfx-plugin/src/lib.rs
@@ -30,14 +30,16 @@
 
 pub mod rendering;
 
+use crate::rendering::{rendering_system, Model, RenderData, RenderQuery};
 use crossbeam::channel::Receiver;
 use ecs::systems::{IntoSystem, SystemParameters};
 use ecs::{Application, ApplicationBuilder, Entity, Executor, Schedule};
+use gfx::engine::Creator;
 use gfx::engine::{EngineError, MainMessage, NoUI};
 use gfx::time::UpdateRate;
-use gfx::Object;
 use std::error::Error;
 use std::fmt::Debug;
+use std::path::Path;
 use std::sync::Mutex;
 use std::thread;
 use std::time::Instant;
@@ -54,7 +56,7 @@ where
     InnerApp: Application + Send,
     AppBuilder: ApplicationBuilder<App = InnerApp>,
 {
-    type App = GraphicalApplication<InnerApp>;
+    type App = GraphicsAppResult<GraphicalApplication<InnerApp>>;
 
     fn add_system<System, Parameters>(mut self, system: System) -> Self
     where
@@ -75,9 +77,13 @@ where
     }
 
     fn build(self) -> Self::App {
-        GraphicalApplication {
+        let (graphics_engine, graphics_engine_handle) = GraphicsEngine::new()
+            .map_err(GraphicalApplicationError::GraphicsEngineInitialization)?;
+        Ok(GraphicalApplication {
             application: self.builder.build(),
-        }
+            graphics_engine: Some(graphics_engine),
+            graphics_engine_handle: Some(graphics_engine_handle),
+        })
     }
 }
 
@@ -85,12 +91,14 @@ where
 #[derive(Debug)]
 pub struct GraphicalApplication<App> {
     application: App,
+    graphics_engine: Option<GraphicsEngine>,
+    graphics_engine_handle: Option<GraphicsEngineHandle>,
 }
 
 // Delegate all methods that are the same as `BasicApplication`.
 impl<App> Application for GraphicalApplication<App>
 where
-    App: Application + Send,
+    App: Application + Send + Sync,
 {
     type Error = GraphicalApplicationError;
 
@@ -98,7 +106,7 @@ where
     fn create_entity(&mut self) -> Result<Entity, Self::Error> {
         self.application
             .create_entity()
-            .map_err(|error| GraphicalApplicationError::InternalApplication(Box::new(error)))
+            .map_err(to_internal_app_error)
     }
 
     #[inline(always)]
@@ -109,7 +117,7 @@ where
     ) -> Result<(), Self::Error> {
         self.application
             .add_component(entity, component)
-            .map_err(|error| GraphicalApplicationError::InternalApplication(Box::new(error)))
+            .map_err(to_internal_app_error)
     }
 
     #[inline(always)]
@@ -125,17 +133,24 @@ where
         &'systems mut self,
         _shutdown_receiver: Receiver<()>,
     ) -> Result<(), Self::Error> {
-        let (graphics_engine, graphics_engine_handle): (GraphicsEngine, GraphicsEngineHandle) =
-            GraphicsEngine::new()
-                .map_err(GraphicalApplicationError::GraphicsEngineInitialization)?;
-
         thread::scope(|scope| {
+            let application = &mut self.application;
+
+            let graphics_engine = self
+                .graphics_engine
+                .take()
+                .ok_or(GraphicalApplicationError::AlreadyStarted)?;
+            let graphics_engine_handle = self
+                .graphics_engine_handle
+                .take()
+                .ok_or(GraphicalApplicationError::AlreadyStarted)?;
+
             thread::Builder::new()
                 .name("simulation".to_string())
                 .spawn_scoped(scope, move || {
                     #[allow(unused)] // todo(#87): use render_data_sender and main_thread_sender
                     let GraphicsEngineHandle {
-                        render_data_sender,
+                        mut render_data_sender,
                         shutdown_receiver,
                         main_thread_sender,
                     } = graphics_engine_handle;
@@ -164,8 +179,14 @@ where
                         }
                     };
 
-                    self.application.add_system(tick_rate_system);
-                    self.application.run::<E, S>(shutdown_receiver)
+                    let rendering_system_wrapper = move |query: RenderQuery| {
+                        let render_data_sender = render_data_sender.clone();
+                        rendering_system(render_data_sender, query);
+                    };
+
+                    application.add_system(tick_rate_system);
+                    application.add_system(rendering_system_wrapper);
+                    application.run::<E, S>(shutdown_receiver)
                 })
                 .expect("there are no null bytes in the name");
 
@@ -173,6 +194,43 @@ where
                 .start()
                 .map_err(GraphicalApplicationError::GraphicsEngineStart)
         })
+    }
+}
+
+fn to_internal_app_error<E: Error + Send + Sync + 'static>(error: E) -> GraphicalApplicationError {
+    GraphicalApplicationError::InternalApplication(Box::new(error))
+}
+
+impl<InnerApp: Application> GraphicalApplication<InnerApp> {
+    /// Loads a model into the application.
+    ///
+    /// The returned [`Model`] is [`Clone`], meaning you can use the same model for multiple entities.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use ecs::{Application, ApplicationBuilder, BasicApplicationBuilder};
+    /// # use gfx_plugin::{Graphical, GraphicalApplicationError};
+    /// # let mut app = BasicApplicationBuilder::default().with_rendering()?.build()?;
+    ///
+    /// let model_path = "path/to/model.obj";
+    /// let model_component = app.load_model(model_path)?;
+    ///
+    /// let entity = app.create_entity()?;
+    /// app.add_component(entity, model_component)?;
+    ///
+    /// Ok::<(), GraphicalApplicationError>(())
+    /// ```
+    pub fn load_model(&mut self, path_str: &str) -> GraphicsAppResult<Model> {
+        let graphics_engine = self
+            .graphics_engine
+            .as_mut()
+            .ok_or(GraphicalApplicationError::MissingGraphicsEngine)?;
+        let path = Path::new(path_str);
+        let handle = graphics_engine
+            .get_object_creator()
+            .load_model(path)
+            .map_err(GraphicalApplicationError::ModelLoad)?;
+        Ok(Model { handle })
     }
 }
 
@@ -188,27 +246,36 @@ pub enum GraphicalApplicationError {
     /// An internal application error has occurred.
     #[error("an internal application error has occurred")]
     InternalApplication(#[source] Box<dyn Error + Send + Sync>),
+    /// The application has already been started, can't start it again.
+    #[error("the application has already been started, can't start it again")]
+    AlreadyStarted,
+    /// The application has already been started, so the graphics engine is not available.
+    #[error("the application has already been started, so the graphics engine is not available")]
+    MissingGraphicsEngine,
+    /// Failed to load model into graphical application.
+    #[error("failed to load model into graphical application")]
+    ModelLoad(#[source] EngineError),
 }
 
 /// Whether an operation on the graphical application succeeded.
-pub type GfxAppResult<T, E = GraphicalApplicationError> = Result<T, E>;
+pub type GraphicsAppResult<T, E = GraphicalApplicationError> = Result<T, E>;
 
 /// Enables rendering functionality.
 pub trait Graphical<RenderedAppBuilder: ApplicationBuilder> {
     /// Initializes and configures rendering functionality, enabling visualization of
     /// the simulation.
-    fn with_rendering(self) -> GfxAppResult<RenderedAppBuilder>;
+    fn with_rendering(self) -> GraphicsAppResult<RenderedAppBuilder>;
 }
 
-type GraphicsEngine = gfx::engine::GraphicsEngine<NoUI, Vec<Object>>;
-type GraphicsEngineHandle = gfx::engine::EngineHandle<Vec<Object>>;
+type GraphicsEngine = gfx::engine::GraphicsEngine<NoUI, RenderData>;
+type GraphicsEngineHandle = gfx::engine::EngineHandle<RenderData>;
 
 impl<InnerApp, AppBuilder> Graphical<GraphicalApplicationBuilder<AppBuilder>> for AppBuilder
 where
     InnerApp: Application + Send,
     AppBuilder: ApplicationBuilder<App = InnerApp>,
 {
-    fn with_rendering(self) -> GfxAppResult<GraphicalApplicationBuilder<AppBuilder>> {
+    fn with_rendering(self) -> GraphicsAppResult<GraphicalApplicationBuilder<AppBuilder>> {
         Ok(GraphicalApplicationBuilder { builder: self })
     }
 }

--- a/crates/gfx-plugin/src/lib.rs
+++ b/crates/gfx-plugin/src/lib.rs
@@ -94,7 +94,7 @@ where
         _shutdown_receiver: Receiver<()>,
     ) -> Result<(), Self::Error> {
         let (graphics_engine, graphics_engine_handle): (GraphicsEngine, GraphicsEngineHandle) =
-            gfx::engine::Engine::new()
+            gfx::engine::GraphicsEngine::new()
                 .map_err(GraphicalApplicationError::GraphicsEngineInitialization)?;
 
         thread::scope(|scope| {
@@ -142,7 +142,7 @@ pub trait Graphical<RenderedApp: Application> {
     fn with_rendering(self) -> GfxAppResult<RenderedApp>;
 }
 
-type GraphicsEngine = gfx::engine::Engine<NoUI, Vec<Object>>;
+type GraphicsEngine = gfx::engine::GraphicsEngine<NoUI, Vec<Object>>;
 type GraphicsEngineHandle = gfx::engine::EngineHandle<Vec<Object>>;
 
 impl<App: Application + Send> Graphical<GraphicalApplication<App>> for App {

--- a/crates/gfx-plugin/src/rendering.rs
+++ b/crates/gfx-plugin/src/rendering.rs
@@ -1,0 +1,33 @@
+//! An abstraction over things that are visible in ECS.
+
+pub use cgmath::{Quaternion, Vector3};
+pub use gfx::ModelHandle;
+
+/// A 3D representation of the shape of an object.
+#[derive(Debug)]
+pub struct Model {
+    _handle: ModelHandle,
+}
+
+/// A location in 3D-space.
+#[derive(Debug)]
+pub struct Position {
+    /// The vector-representation of the position.
+    pub vector: Vector3<f32>,
+}
+
+/// An orientation in 3D-space.
+#[derive(Debug)]
+pub struct Rotation {
+    /// Rotation represented as a quaternion.
+    pub rotation: Quaternion<f32>,
+}
+
+/// At which scale to render the object.
+///
+/// Each axis can be scaled differently to stretch the object.
+#[derive(Debug)]
+pub struct Scale {
+    /// The vector-representation of the scale.
+    pub vector: Vector3<f32>,
+}

--- a/crates/gfx-plugin/src/rendering.rs
+++ b/crates/gfx-plugin/src/rendering.rs
@@ -129,7 +129,8 @@ pub struct RenderedEntityBuilder<'app, App> {
 }
 
 impl<InnerApp: Application> GraphicalApplication<InnerApp> {
-    /// Constructs a new [`RenderedEntityBuilder`] which can be used to build
+    /// Constructs a new [`RenderedEntityBuilder`] which can be used to build entities which
+    /// will be visible in the application window.
     pub fn rendered_entity_builder(
         &mut self,
         model: Model,

--- a/crates/gfx-plugin/src/rendering.rs
+++ b/crates/gfx-plugin/src/rendering.rs
@@ -114,7 +114,7 @@ pub enum RenderedEntityBuilderError {
     ComponentAdding(#[source] Box<dyn Error + Send + Sync>),
 }
 
-/// Whether an operation on the graphical application succeeded.
+/// Whether an operation on the rendered entity builder succeeded.
 pub type RenderedEntityBuilderResult<T, E = RenderedEntityBuilderError> = Result<T, E>;
 
 /// Builds a visible (i.e. rendered) entity.

--- a/crates/gfx/src/engine.rs
+++ b/crates/gfx/src/engine.rs
@@ -70,7 +70,7 @@ const AVERAGE_FPS_SAMPLES: usize = 128;
 
 /// The driving actor of all windowing, rendering and simulation.
 #[derive(Debug)]
-pub struct Engine<UIFn, RenderData> {
+pub struct GraphicsEngine<UIFn, RenderData> {
     main: MainThread<RenderData>,
     /// The window management wrapper.
     windowing: Windowing<UIFn, RenderData>,
@@ -127,7 +127,7 @@ pub struct EngineHandle<RenderData> {
     pub main_thread_sender: Sender<MainMessage>,
 }
 
-impl<UI, RenderData> Engine<UI, RenderData>
+impl<UI, RenderData> GraphicsEngine<UI, RenderData>
 where
     UI: UIRenderer + 'static,
     for<'a> RenderData: IntoIterator<Item = Object> + Send + 'a,
@@ -175,7 +175,7 @@ where
 
     /// Initializes and starts all state and threads, beginning the core event-loops of the program.
     pub fn start(self) -> EngineResult<()> {
-        let Engine {
+        let GraphicsEngine {
             mut main,
             windowing,
             renderer,

--- a/crates/gfx/src/lib.rs
+++ b/crates/gfx/src/lib.rs
@@ -32,7 +32,8 @@ pub use egui;
 
 use crate::camera::{Camera, Projection};
 pub use crate::instance::Transform;
-use crate::renderer::{InstancesHandle, ModelHandle};
+use crate::renderer::InstancesHandle;
+pub use crate::renderer::ModelHandle;
 
 mod camera;
 pub mod engine;

--- a/crates/gfx/src/lib.rs
+++ b/crates/gfx/src/lib.rs
@@ -32,7 +32,6 @@ pub use egui;
 
 use crate::camera::{Camera, Projection};
 pub use crate::instance::Transform;
-use crate::renderer::InstancesHandle;
 pub use crate::renderer::ModelHandle;
 
 mod camera;
@@ -96,17 +95,6 @@ impl CameraUniform {
 
 /// A buffer that contains simulation results that need to be rendered.
 pub type SimulationBuffer<T> = ArrayQueue<T>;
-
-/// A graphical object that can be rendered.
-#[derive(Debug, Copy, Clone)]
-pub struct Object {
-    /// The orientation and location.
-    pub transform: Transform,
-    /// Which visual representation to use.
-    pub model: ModelHandle,
-    /// Which group of instances it belongs to.
-    instances_group: InstancesHandle,
-}
 
 /// Whether an event should continue to propagate, or be consumed.
 #[derive(Eq, PartialEq)]

--- a/crates/gfx/src/renderer.rs
+++ b/crates/gfx/src/renderer.rs
@@ -538,7 +538,10 @@ where
         CameraUpdateFn: FnMut(&mut Camera, &UpdateRate),
     {
         self.camera_uniform.update_data(&self.queue, |camera_data| {
+            // todo(#91): don't handle camera controlling in here (the CameraUpdateFn should be
+            // todo(#91): a system in the ECS).
             update_camera(&mut self.camera, time);
+
             camera_data.update_view_projection(&self.camera, &self.projection)
         });
 
@@ -561,6 +564,7 @@ where
             },
         );
 
+        // todo(#92): extract lights from renderer into ECS.
         // Animate light rotation
         const DEGREES_PER_SECOND: f32 = 60.0;
         self.light_uniform.update_data(&self.queue, |light| {

--- a/crates/gfx/src/renderer.rs
+++ b/crates/gfx/src/renderer.rs
@@ -1,4 +1,5 @@
 use std::any::TypeId;
+use std::collections::HashMap;
 use std::iter;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
@@ -6,7 +7,6 @@ use std::path::{Path, PathBuf};
 use cgmath::prelude::*;
 use cgmath::{Deg, Quaternion, Vector3};
 use derivative::Derivative;
-use itertools::Itertools;
 use thiserror::Error;
 use tracing::info;
 use winit::window::Window;
@@ -23,7 +23,7 @@ use crate::shader_locations::{
 use crate::texture::Texture;
 use crate::time::UpdateRate;
 use crate::uniform::{Uniform, UniformBinding};
-use crate::{resources, CameraUniform, Object};
+use crate::{resources, CameraUniform};
 
 #[derive(Error, Debug)]
 pub enum RendererError {
@@ -86,6 +86,8 @@ pub(crate) struct Renderer<UIFn, Data> {
     material_bind_group_layout: wgpu::BindGroupLayout,
     /// Model instances, to allow for one model to be shown multiple times with different transforms.
     instances: Vec<ModelInstances>,
+    /// Maps each model to which group of instances they belong to.
+    model_to_instance: HashMap<ModelHandle, InstancesHandle>,
     /// Used for depth-testing (z-culling) to render pixels in front of each other correctly.
     depth_texture: Texture,
     /// The models that can be rendered.
@@ -137,6 +139,7 @@ impl<UIFn, Data> Renderer<UIFn, Data> {
 
         let index = self.instances.len();
         self.instances.push(instances);
+        self.model_to_instance.insert(model, index);
         Ok(index)
     }
 
@@ -345,6 +348,7 @@ impl<UIFn, Data> Renderer<UIFn, Data> {
             render_pipeline,
             material_bind_group_layout,
             instances: vec![],
+            model_to_instance: HashMap::default(),
             depth_texture,
             models: vec![],
             light_uniform,
@@ -523,7 +527,7 @@ where
 
 impl<UIFn, Data> Renderer<UIFn, Data>
 where
-    Data: IntoIterator<Item = Object>,
+    for<'a> Data: IntoIterator<Item = (ModelHandle, Vec<Transform>)> + Send + 'a,
 {
     pub(crate) fn update<CameraUpdateFn>(
         &mut self,
@@ -538,14 +542,24 @@ where
             camera_data.update_view_projection(&self.camera, &self.projection)
         });
 
-        Itertools::group_by(objects.into_iter(), |object| object.instances_group)
-            .into_iter()
-            .for_each(|(instances_handle, object_instances)| {
-                let transforms = object_instances.map(|object| object.transform).collect();
-                if let Some(instances) = self.instances.get_mut(instances_handle) {
-                    instances.update_transforms(&self.device, transforms)
+        objects.into_iter().for_each(
+            |(model_handle, transforms): (ModelHandle, Vec<Transform>)| {
+                if let Some(&instances_handle) = self.model_to_instance.get(&model_handle) {
+                    if let Some(instances) = self.instances.get_mut(instances_handle) {
+                        instances.update_transforms(&self.device, transforms)
+                    } else {
+                        panic!(
+                            "A model was mapped to an instance which no longer exists.\
+                        This should be impossible, but if it happens it might mean that \
+                        a ModelInstances was removed without updating the hashmap."
+                        )
+                    }
+                } else {
+                    self.create_model_instances(model_handle, transforms)
+                        .expect("the end user can't mess it up, handles are constructed correctly");
                 }
-            });
+            },
+        );
 
         // Animate light rotation
         const DEGREES_PER_SECOND: f32 = 60.0;

--- a/crates/scheduler/examples/parallel.rs
+++ b/crates/scheduler/examples/parallel.rs
@@ -2,7 +2,7 @@ use color_eyre::Report;
 use crossbeam::channel::unbounded;
 use ecs::logging::Loggable;
 use ecs::systems::{Read, Write};
-use ecs::{Application, BasicApplication};
+use ecs::{Application, ApplicationBuilder, BasicApplicationBuilder};
 use scheduler::executor::WorkerPool;
 use scheduler::schedule::PrecedenceGraph;
 use tracing::{error, info, instrument, warn};
@@ -10,12 +10,13 @@ use tracing::{error, info, instrument, warn};
 // a simple example of how to use the crate `ecs`
 #[instrument]
 fn main() -> Result<(), Report> {
-    let mut app = BasicApplication::default()
+    let mut app = BasicApplicationBuilder::default()
         .with_tracing()?
         .add_system(basic_system)
         .add_system(read_b_system)
         .add_system(write_b_system)
-        .add_system(read_write_many);
+        .add_system(read_write_many)
+        .build();
 
     for i in 0..20 {
         let entity = app.create_entity()?;

--- a/crates/scheduler/tests/worker_pool_tests.rs
+++ b/crates/scheduler/tests/worker_pool_tests.rs
@@ -1,6 +1,6 @@
 use crossbeam::channel::unbounded;
 use crossbeam::sync::Parker;
-use ecs::{Application, BasicApplication};
+use ecs::{Application, ApplicationBuilder, BasicApplicationBuilder};
 //noinspection RsUnusedImport - CLion can't recognize that `Write` is being used.
 use ecs::systems::Write;
 //noinspection RsUnusedImport - CLion can't recognize that `timeout` is being used.
@@ -43,9 +43,10 @@ fn scheduler_runs_application() {
         debug!("mutated to {:?}!", health);
     }
 
-    let mut application: BasicApplication = BasicApplication::default()
+    let mut application = BasicApplicationBuilder::default()
         .add_system(verify_run_system)
-        .add_system(system_with_read_and_write);
+        .add_system(system_with_read_and_write)
+        .build();
 
     let entity0 = application.create_entity().unwrap();
     let entity1 = application.create_entity().unwrap();
@@ -115,7 +116,9 @@ fn run_application_with_fake_systems(
             }
         });
 
-    let mut application: BasicApplication = BasicApplication::default().add_systems(systems);
+    let mut application = BasicApplicationBuilder::default()
+        .add_systems(systems)
+        .build();
 
     application
         .run::<WorkerPool, PrecedenceGraph>(shutdown_receiver)


### PR DESCRIPTION
Entities with specific rendering-components are now rendered in the application window.

In the below gif, the rotating cubes are entirely pure entities in the ECS. The light is not yet converted to ECS (see #92).
![Zoom_bm9HabYNEh](https://user-images.githubusercontent.com/12572888/229791776-d94af893-77f0-49c6-b17c-f9c7cf28edc4.gif)

The components that make an entity renderable are:
* `Model` which specifies which meshes/materials to use when rendering the entity,
* `Position` which specifies the world-space location of the entity (this needs to be used instead of a custom `Position` component in order for the position of the rendered entity to change),
* `Rotation` which specifies the model-space rotation of the entity,
* `Scale` which can rescale the entity.

These are all currently required on an entity for it to be rendered, but to make construction of visible entities that don't want to specify all of these components simpler, we have created a `RenderedEntityBuilder`:
```rust
let cube_model = app.load_model("cube.obj")?;

let _entity = app
    .rendered_entity_builder(cube_model)?
    .with_position(position)
    .with_scale(scale)
    .build()?;
```
here, the rotation is not specified and instead a default value is used. `Position`, `Scale` and `Rotation` are all optional, but you need to always specify a `Model`.

Closes #87 