### PR TITLE
Hotfix renderer configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +682,37 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -1050,6 +1116,7 @@ dependencies = [
  "criterion",
  "crossbeam",
  "derivative",
+ "derive_builder",
  "egui",
  "egui-wgpu",
  "egui-winit",
@@ -1246,6 +1313,12 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2567,6 +2640,12 @@ name = "strict-num"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df65f20698aeed245efdde3628a6b559ea1239bbb871af1b6e3b58c413b2bd1"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structmeta"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ pollster = "0.3"      # To be able to block on async functions
 anyhow = "1.0"        # For simple error handling
 fs_extra = "1.2"      # For extra file system functions
 glob = "0.3"          # For querying the file system in a unix-manner
+derive_builder = "0.12"# Automatically implements the builder pattern for structs

--- a/crates/gfx-plugin/src/lib.rs
+++ b/crates/gfx-plugin/src/lib.rs
@@ -37,7 +37,7 @@ pub use cgmath::Deg;
 use crossbeam::channel::Receiver;
 use ecs::systems::{IntoSystem, SystemParameters};
 use ecs::{Application, ApplicationBuilder, Entity, Executor, Schedule};
-use gfx::engine::{Creator, GraphicsOptionsBuilder, RendererOptionsBuilder};
+use gfx::engine::{Creator, GraphicsOptionsBuilder};
 use gfx::engine::{EngineError, MainMessage, NoUI};
 use gfx::time::UpdateRate;
 use std::error::Error;
@@ -52,11 +52,7 @@ use thiserror::Error;
 #[derive(Debug, Default)]
 pub struct GraphicalApplicationBuilder<AppBuilder> {
     app_builder: AppBuilder,
-    camera_movement_speed: Option<f32>,
-    camera_mouse_sensitivity: Option<f32>,
-    far_clipping_plane: Option<f32>,
-    near_clipping_plane: Option<f32>,
-    field_of_view: Option<Deg<f32>>,
+    graphics_options_builder: GraphicsOptionsBuilder,
 }
 
 impl<InnerApp, AppBuilder> ApplicationBuilder for GraphicalApplicationBuilder<AppBuilder>
@@ -85,30 +81,8 @@ where
     }
 
     fn build(self) -> Self::App {
-        let mut graphics_options_builder = GraphicsOptionsBuilder::default();
-        if let Some(speed) = self.camera_movement_speed {
-            graphics_options_builder.camera_movement_speed(speed);
-        }
-        if let Some(sensitivity) = self.camera_mouse_sensitivity {
-            graphics_options_builder.camera_mouse_sensitivity(sensitivity);
-        }
-
-        let mut renderer_options_builder = RendererOptionsBuilder::default();
-        if let Some(distance) = self.far_clipping_plane {
-            renderer_options_builder.far_clipping_plane(distance);
-        }
-        if let Some(distance) = self.near_clipping_plane {
-            renderer_options_builder.near_clipping_plane(distance);
-        }
-        if let Some(degrees) = self.field_of_view {
-            renderer_options_builder.field_of_view(degrees);
-        }
-
-        let renderer_options = renderer_options_builder
-            .build()
-            .expect("default renderer options should be valid");
-        graphics_options_builder.renderer_options(renderer_options);
-        let graphics_options = graphics_options_builder
+        let graphics_options = self
+            .graphics_options_builder
             .build()
             .expect("default graphics options should be valid");
 
@@ -125,13 +99,14 @@ where
 impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
     /// Sets how fast the camera moves around.
     pub fn camera_movement_speed(mut self, speed: f32) -> Self {
-        self.camera_movement_speed = Some(speed);
+        self.graphics_options_builder.camera_movement_speed(speed);
         self
     }
 
     /// Sets how quickly the camera rotates when the mouse moves.
     pub fn camera_mouse_sensitivity(mut self, sensitivity: f32) -> Self {
-        self.camera_mouse_sensitivity = Some(sensitivity);
+        self.graphics_options_builder
+            .camera_mouse_sensitivity(sensitivity);
         self
     }
 
@@ -139,7 +114,9 @@ impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
     ///
     /// This defines the far-end of the view frustum, outside of which nothing is rendered.
     pub fn far_clipping_plane(mut self, distance: f32) -> Self {
-        self.far_clipping_plane = Some(distance);
+        self.graphics_options_builder
+            .renderer_options_or_default()
+            .far_clipping_plane = distance;
         self
     }
 
@@ -147,7 +124,9 @@ impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
     ///
     /// This defines the start of the view frustum, outside of which nothing is rendered.
     pub fn near_clipping_plane(mut self, distance: f32) -> Self {
-        self.near_clipping_plane = Some(distance);
+        self.graphics_options_builder
+            .renderer_options_or_default()
+            .near_clipping_plane = distance;
         self
     }
 
@@ -155,7 +134,9 @@ impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
     ///
     /// Note: this is the vertical FOV.
     pub fn field_of_view(mut self, degrees: Deg<f32>) -> Self {
-        self.field_of_view = Some(degrees);
+        self.graphics_options_builder
+            .renderer_options_or_default()
+            .field_of_view = degrees;
         self
     }
 }

--- a/crates/gfx-plugin/src/lib.rs
+++ b/crates/gfx-plugin/src/lib.rs
@@ -158,7 +158,7 @@ impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
     /// ```
     ///
     /// The application code would then look like this:
-    /// ```no_run
+    /// ```ignore
     /// # use ecs::{ApplicationBuilder, BasicApplicationBuilder};
     /// # use gfx_plugin::Graphical;
     /// let mut app = BasicApplicationBuilder::default()
@@ -168,7 +168,7 @@ impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
     /// ```
     /// and there would be a build script called `build.rs` located at the root of the crate
     /// (next to `src`), with the contents:
-    /// ```no_run
+    /// ```ignore
     /// # use std::env;
     /// // This tells cargo to rerun this script if something in assets// changes.
     /// println!("cargo:rerun-if-changed=assets/*");
@@ -182,7 +182,7 @@ impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
     ///
     /// Then, in any calls to [`GraphicalApplication::load_model`] you need only specify
     /// the name of the asset inside of `assets/`:
-    /// ```
+    /// ```ignore
     /// # use ecs::{ApplicationBuilder, BasicApplicationBuilder};
     /// # use gfx_plugin::Graphical;
     /// # let mut app = BasicApplicationBuilder::default()

--- a/crates/gfx-plugin/src/lib.rs
+++ b/crates/gfx-plugin/src/lib.rs
@@ -170,7 +170,7 @@ impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
     /// (next to `src`), with the contents:
     /// ```ignore
     /// # use std::env;
-    /// // This tells cargo to rerun this script if something in assets// changes.
+    /// // This tells cargo to rerun this script if something in assets/ changes.
     /// println!("cargo:rerun-if-changed=assets/*");
     ///
     /// let out_dir = env::var("OUT_DIR")?;

--- a/crates/gfx-plugin/src/lib.rs
+++ b/crates/gfx-plugin/src/lib.rs
@@ -89,19 +89,19 @@ where
         if let Some(speed) = self.camera_movement_speed {
             graphics_options_builder.camera_movement_speed(speed);
         }
-        if let Some(speed) = self.camera_mouse_sensitivity {
-            graphics_options_builder.camera_mouse_sensitivity(speed);
+        if let Some(sensitivity) = self.camera_mouse_sensitivity {
+            graphics_options_builder.camera_mouse_sensitivity(sensitivity);
         }
 
         let mut renderer_options_builder = RendererOptionsBuilder::default();
-        if let Some(speed) = self.far_clipping_plane {
-            renderer_options_builder.far_clipping_plane(speed);
+        if let Some(distance) = self.far_clipping_plane {
+            renderer_options_builder.far_clipping_plane(distance);
         }
-        if let Some(speed) = self.near_clipping_plane {
-            renderer_options_builder.near_clipping_plane(speed);
+        if let Some(distance) = self.near_clipping_plane {
+            renderer_options_builder.near_clipping_plane(distance);
         }
-        if let Some(speed) = self.field_of_view {
-            renderer_options_builder.field_of_view(speed);
+        if let Some(degrees) = self.field_of_view {
+            renderer_options_builder.field_of_view(degrees);
         }
 
         let renderer_options = renderer_options_builder

--- a/crates/gfx-plugin/src/lib.rs
+++ b/crates/gfx-plugin/src/lib.rs
@@ -141,7 +141,7 @@ impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
     }
 
     /// Sets the directory in which build artifacts are placed into
-    /// (i.e. where `/assets` is located).
+    /// (i.e. where `assets/` is located).
     ///
     /// # Examples
     /// Usually you set this to `env!("OUT_DIR")`, and then you need to have a build-script
@@ -170,7 +170,7 @@ impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
     /// (next to `src`), with the contents:
     /// ```no_run
     /// # use std::env;
-    /// // This tells cargo to rerun this script if something in /assets/ changes.
+    /// // This tells cargo to rerun this script if something in assets// changes.
     /// println!("cargo:rerun-if-changed=assets/*");
     ///
     /// let out_dir = env::var("OUT_DIR")?;
@@ -195,6 +195,16 @@ impl<AppBuilder> GraphicalApplicationBuilder<AppBuilder> {
         self.graphics_options_builder
             .renderer_options_or_default()
             .output_directory = path.to_owned();
+        self
+    }
+
+    /// Sets the file name of a model asset to use for the lights.
+    ///
+    /// Note that this path is located inside of the `assets/` directory.
+    pub fn light_model(mut self, file_name: &str) -> Self {
+        self.graphics_options_builder
+            .renderer_options_or_default()
+            .light_model_file_name = file_name.to_owned();
         self
     }
 }

--- a/crates/gfx/Cargo.toml
+++ b/crates/gfx/Cargo.toml
@@ -28,6 +28,7 @@ crossbeam = { workspace = true }    # Concurrency primitives
 ring-channel = { workspace = true } # A ring-buffer multi-producer multi-consumer channel for bounded message-queues
 pollster = { workspace = true }     # To be able to block on async functions
 itertools = { workspace = true }    # Helpers for working with iterators
+derive_builder = { workspace = true}# Automatically implements the builder pattern for structs
 
 [build-dependencies]
 anyhow = { workspace = true }       # For simple error handling

--- a/crates/gfx/build.rs
+++ b/crates/gfx/build.rs
@@ -4,7 +4,7 @@ use fs_extra::dir::CopyOptions;
 use std::env;
 
 fn main() -> Result<()> {
-    // This tells cargo to rerun this script if something in assets// changes.
+    // This tells cargo to rerun this script if something in assets/ changes.
     println!("cargo:rerun-if-changed=assets/*");
 
     let out_dir = env::var("OUT_DIR")?;

--- a/crates/gfx/build.rs
+++ b/crates/gfx/build.rs
@@ -4,7 +4,7 @@ use fs_extra::dir::CopyOptions;
 use std::env;
 
 fn main() -> Result<()> {
-    // This tells cargo to rerun this script if something in /assets/ changes.
+    // This tells cargo to rerun this script if something in assets// changes.
     println!("cargo:rerun-if-changed=assets/*");
 
     let out_dir = env::var("OUT_DIR")?;

--- a/crates/gfx/src/engine.rs
+++ b/crates/gfx/src/engine.rs
@@ -129,7 +129,7 @@ pub struct EngineHandle<RenderData, LightData> {
 }
 
 /// Configurable aspects of the graphics engine.
-#[derive(Debug, Builder, Copy, Clone, PartialEq)]
+#[derive(Debug, Builder, Clone, PartialEq)]
 pub struct GraphicsOptions {
     /// How fast the camera moves around.
     #[builder(default = "20.0")]
@@ -401,18 +401,18 @@ pub trait Creator {
     /// use gfx::engine::{Creator, EngineError, EngineResult, GenericResult};
     ///
     /// fn initialize_gfx(mut creator: impl Creator) -> EngineResult<()> {
-    ///     let model_path = std::path::Path::new("path/to/model.obj");
+    ///     let model_path = std::path::Path::new("model.obj");
     ///     let model_handle = creator.load_model(model_path)?;
     ///     Ok(())
     /// }
     /// ```
-    fn load_model(&mut self, path: &Path) -> EngineResult<ModelHandle>;
+    fn load_model(&mut self, file_path: &Path) -> EngineResult<ModelHandle>;
 }
 
 impl<UIFn, Data, LightData> Creator for Renderer<UIFn, Data, LightData> {
     #[instrument(skip(self))]
-    fn load_model(&mut self, path: &Path) -> EngineResult<ModelHandle> {
-        self.load_model(path)
-            .map_err(|e| EngineError::ModelLoad(Box::new(e), path.to_owned()))
+    fn load_model(&mut self, file_path: &Path) -> EngineResult<ModelHandle> {
+        self.load_model(file_path)
+            .map_err(|e| EngineError::ModelLoad(Box::new(e), file_path.to_owned()))
     }
 }

--- a/crates/gfx/src/engine.rs
+++ b/crates/gfx/src/engine.rs
@@ -130,6 +130,7 @@ pub struct EngineHandle<RenderData, LightData> {
 
 /// Configurable aspects of the graphics engine.
 #[derive(Debug, Builder, Clone, PartialEq)]
+#[builder(derive(Debug))]
 pub struct GraphicsOptions {
     /// How fast the camera moves around.
     #[builder(default = "20.0")]
@@ -138,7 +139,7 @@ pub struct GraphicsOptions {
     #[builder(default = "1.0")]
     pub camera_mouse_sensitivity: f32,
     /// Configuration of the renderer.
-    #[builder(default = "self.default_renderer()")]
+    #[builder(setter(custom), default = "self.default_renderer()")]
     pub renderer_options: RendererOptions,
 }
 
@@ -147,6 +148,17 @@ impl GraphicsOptionsBuilder {
         RendererOptionsBuilder::default()
             .build()
             .expect("default values should be valid")
+    }
+
+    /// Gets the renderer configuration. If none was set, it creates a default and stores
+    /// that before returning a reference to it.
+    pub fn renderer_options_or_default(&mut self) -> &mut RendererOptions {
+        if self.renderer_options.is_none() {
+            self.renderer_options = Some(self.default_renderer());
+        }
+        self.renderer_options
+            .as_mut()
+            .expect("just assigned a Some-value")
     }
 }
 

--- a/crates/gfx/src/renderer.rs
+++ b/crates/gfx/src/renderer.rs
@@ -134,9 +134,14 @@ pub struct RendererOptions {
     /// Note: this is the vertical FOV.
     #[builder(default = "Deg(70.0)")]
     pub field_of_view: Deg<f32>,
-    /// Directory in which build artifacts are placed into (i.e. where `/assets` is located).
+    /// Directory in which build artifacts are placed into (i.e. where `assets/` is located).
     #[builder(default = r#"env!("OUT_DIR").to_owned()"#)]
     pub output_directory: String,
+    /// File name of a model asset to use for the lights.
+    ///
+    /// Note that this path is located inside of the `assets/` directory.
+    #[builder(default = r#"String::from("cube.obj")"#)]
+    pub light_model_file_name: String,
 }
 
 const ASSETS_PATH: &str = "assets";
@@ -383,9 +388,9 @@ impl<UIFn, Data, LightData> Renderer<UIFn, Data, LightData> {
 
         let mut models = vec![];
 
-        let light_model_file_name = Path::new("cube.obj");
+        let light_model_file_name = PathBuf::from(options.light_model_file_name);
         let light_model = Self::load_model_raw(
-            light_model_file_name,
+            light_model_file_name.as_path(),
             &device,
             &queue,
             &material_bind_group_layout,

--- a/crates/gfx/src/renderer.rs
+++ b/crates/gfx/src/renderer.rs
@@ -96,12 +96,14 @@ pub(crate) struct Renderer<UIFn, Data, LightData> {
     /// The uniform-representation of the light. (currently only single light supported)
     light_uniform: Uniform<PointLightUniform>,
     /// Which model to render the light with, when light "debugging" is enabled.
-    light_model: Model,
+    light_model: ModelHandle,
     /// How the GPU acts on lights.
     light_render_pipeline: wgpu::RenderPipeline,
     /// A render pass for the GUI from egui.
     #[derivative(Debug = "ignore")]
     egui_renderer: egui_wgpu::Renderer,
+    /// Where to find the assets folder (which contains models and the like).
+    pub(crate) output_directory: PathBuf,
     /// The function called every frame to render the UI.
     user_interface: PhantomData<UIFn>,
     _data: PhantomData<Data>,
@@ -115,7 +117,7 @@ pub type ModelHandle = usize;
 pub type InstancesHandle = usize;
 
 /// Configurable aspects of the renderer.
-#[derive(Debug, Builder, Copy, Clone, PartialEq)]
+#[derive(Debug, Builder, Clone, PartialEq)]
 pub struct RendererOptions {
     /// How far away (in camera-space along the z-axis) the far clipping plane is located.
     ///
@@ -132,20 +134,43 @@ pub struct RendererOptions {
     /// Note: this is the vertical FOV.
     #[builder(default = "Deg(70.0)")]
     pub field_of_view: Deg<f32>,
+    /// Directory in which build artifacts are placed into (i.e. where `/assets` is located).
+    #[builder(default = r#"env!("OUT_DIR").to_owned()"#)]
+    pub output_directory: String,
 }
 
+const ASSETS_PATH: &str = "assets";
+
 impl<UIFn, Data, LightData> Renderer<UIFn, Data, LightData> {
-    pub(crate) fn load_model(&mut self, path: &Path) -> RendererResult<ModelHandle> {
-        let obj_model = resources::load_model(
-            path,
+    pub(crate) fn load_model(&mut self, file_path: &Path) -> RendererResult<ModelHandle> {
+        Self::load_model_raw(
+            file_path,
             &self.device,
             &self.queue,
             &self.material_bind_group_layout,
+            &mut self.models,
+            self.output_directory.as_path(),
         )
-        .map_err(|e| ModelLoad(e, Box::new(path.to_owned())))?;
+    }
 
-        let index = self.models.len();
-        self.models.push(obj_model);
+    /// A version of [`Renderer::load_model`] that needs all its parameters explicitly passed in.
+    /// (i.e. no need for `self`.)
+    fn load_model_raw(
+        file_path: &Path,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        layout: &wgpu::BindGroupLayout,
+        models: &mut Vec<Model>,
+        output_directory: &Path,
+    ) -> Result<ModelHandle, RendererError> {
+        let path_buffer = output_directory.join(ASSETS_PATH).join(file_path);
+        let path = path_buffer.as_path();
+
+        let obj_model = resources::load_model(path, device, queue, layout)
+            .map_err(|e| ModelLoad(e, Box::new(path.to_owned())))?;
+
+        let index = models.len();
+        models.push(obj_model);
         Ok(index)
     }
 
@@ -306,15 +331,6 @@ impl<UIFn, Data, LightData> Renderer<UIFn, Data, LightData> {
             .binding(UniformBinding(0))
             .build();
 
-        let light_model_file_name = Path::new("cube.obj");
-        let light_model = resources::load_model(
-            light_model_file_name,
-            &device,
-            &queue,
-            &material_bind_group_layout,
-        )
-        .map_err(|e| ModelLoad(e, Box::new(light_model_file_name.to_owned())))?;
-
         let render_pipeline_layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Render Pipeline Layout"),
@@ -365,6 +381,18 @@ impl<UIFn, Data, LightData> Renderer<UIFn, Data, LightData> {
 
         let depth_texture = Texture::create_depth_texture(&device, &config, "depth_texture");
 
+        let mut models = vec![];
+
+        let light_model_file_name = Path::new("cube.obj");
+        let light_model = Self::load_model_raw(
+            light_model_file_name,
+            &device,
+            &queue,
+            &material_bind_group_layout,
+            &mut models,
+            Path::new(&options.output_directory),
+        )?;
+
         Ok(Self {
             surface,
             device,
@@ -380,11 +408,12 @@ impl<UIFn, Data, LightData> Renderer<UIFn, Data, LightData> {
             instances: vec![],
             model_to_instance: HashMap::default(),
             depth_texture,
-            models: vec![],
+            models,
             light_uniform,
             light_render_pipeline,
             light_model,
             egui_renderer,
+            output_directory: PathBuf::from(options.output_directory),
             user_interface: PhantomData,
             _data: PhantomData,
             _light_data: PhantomData,
@@ -479,7 +508,7 @@ where
                 render_pass.push_debug_group("Drawing light.");
                 render_pass.set_pipeline(&self.light_render_pipeline);
                 render_pass.draw_light_model(
-                    &self.light_model,
+                    &self.models[self.light_model],
                     &self.camera_uniform.bind_group,
                     &self.light_uniform.bind_group,
                 );


### PR DESCRIPTION
The renderer has a bunch of parameters that change how the visuals look, but previously they were not configurable. This PR simply adds builders that make the parameters configurable.

To configure a graphical application, simply do:
```rust
    let mut app = BasicApplicationBuilder::default()
        .with_rendering()?
        .camera_movement_speed(10.0)
        .far_clipping_plane(10_000.0)
        .build()?;
```