### PR TITLE
Hotfix Remove redundant option from ComponentVec

### DIFF
--- a/crates/ecs/src/filter.rs
+++ b/crates/ecs/src/filter.rs
@@ -39,10 +39,10 @@ impl<Component: Debug + Send + Sync + 'static + Sized> SystemParameter for With<
         Ok(())
     }
 
-    unsafe fn fetch_parameter(_: &mut Self::BorrowedData<'_>) -> Option<Option<Self>> {
-        Some(Some(Self {
+    unsafe fn fetch_parameter(_: &mut Self::BorrowedData<'_>) -> Option<Self> {
+        Some(Self {
             phantom: PhantomData::default(),
-        }))
+        })
     }
 
     fn component_accesses() -> Vec<ComponentAccessDescriptor> {
@@ -119,11 +119,11 @@ macro_rules! binary_filter_operation {
                 Ok(())
             }
 
-            unsafe fn fetch_parameter(_: &mut Self::BorrowedData<'_>) -> Option<Option<Self>> {
-                Some(Some(Self {
+            unsafe fn fetch_parameter(_: &mut Self::BorrowedData<'_>) -> Option<Self> {
+                Some(Self {
                     left: PhantomData::default(),
                     right: PhantomData::default(),
-                }))
+                })
             }
 
             fn component_accesses() -> Vec<ComponentAccessDescriptor> {
@@ -183,10 +183,10 @@ impl<T: Filter + SystemParameter> SystemParameter for Not<T> {
         Ok(())
     }
 
-    unsafe fn fetch_parameter(_: &mut Self::BorrowedData<'_>) -> Option<Option<Self>> {
-        Some(Some(Self {
+    unsafe fn fetch_parameter(_: &mut Self::BorrowedData<'_>) -> Option<Self> {
+        Some(Self {
             phantom: PhantomData::default(),
-        }))
+        })
     }
 
     fn component_accesses() -> Vec<ComponentAccessDescriptor> {
@@ -234,8 +234,8 @@ mod tests {
             Ok(())
         }
 
-        unsafe fn fetch_parameter(_: &mut Self::BorrowedData<'_>) -> Option<Option<Self>> {
-            Some(Some(Self {}))
+        unsafe fn fetch_parameter(_: &mut Self::BorrowedData<'_>) -> Option<Self> {
+            Some(Self {})
         }
 
         fn component_accesses() -> Vec<ComponentAccessDescriptor> {
@@ -307,7 +307,7 @@ mod tests {
 
         // SAFETY: This is safe because the result from fetch_parameter will not outlive borrowed
         unsafe {
-            if let Some(Some(result)) =
+            if let Some(result) =
                 <Read<TestResult> as SystemParameter>::fetch_parameter(&mut borrowed)
             {
                 Ok(result.0)

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -432,7 +432,7 @@ impl Archetype {
         let mut component_vec = self.borrow_component_vec_mut::<ComponentType>().ok_or(
             ArchetypeError::CouldNotBorrowComponentVec(TypeId::of::<ComponentType>()),
         )?;
-        component_vec.push(Some(component));
+        component_vec.push(component);
 
         Ok(())
     }
@@ -535,9 +535,9 @@ pub struct World {
     component_typeid_to_archetype_indices: HashMap<TypeId, HashSet<ArchetypeIndex>>,
 }
 
-type ReadComponentVec<'a, ComponentType> = Option<RwLockReadGuard<'a, Vec<Option<ComponentType>>>>;
+type ReadComponentVec<'a, ComponentType> = Option<RwLockReadGuard<'a, Vec<ComponentType>>>;
 type WriteComponentVec<'a, ComponentType> =
-    Option<RwLockWriteGuard<'a, Vec<Option<ComponentType>>>>;
+    Option<RwLockWriteGuard<'a, Vec<ComponentType>>>;
 type TargetArchSourceTargetIDs = (Option<ArchetypeIndex>, HashSet<TypeId>, HashSet<TypeId>);
 
 enum ArchetypeMutation {
@@ -986,7 +986,7 @@ impl Default for World {
 
 fn create_raw_component_vec<ComponentType: Debug + Send + Sync + 'static>() -> Box<dyn ComponentVec>
 {
-    Box::new(RwLock::new(Vec::<Option<ComponentType>>::new()))
+    Box::new(RwLock::new(Vec::<ComponentType>::new()))
 }
 
 fn borrow_component_vec<ComponentType: 'static>(
@@ -1038,7 +1038,7 @@ fn intersection_of_multiple_sets<T: Hash + Eq + Clone>(sets: &[HashSet<T>]) -> H
         .collect()
 }
 
-type ComponentVecImpl<ComponentType> = RwLock<Vec<Option<ComponentType>>>;
+type ComponentVecImpl<ComponentType> = RwLock<Vec<ComponentType>>;
 
 trait ComponentVec: Debug + Send + Sync {
     fn as_any(&self) -> &dyn Any;
@@ -1298,7 +1298,7 @@ mod tests {
     }
 
     type UnwrappedReadComponentVec<'a, ComponentType> =
-        RwLockReadGuard<'a, Vec<Option<ComponentType>>>;
+        RwLockReadGuard<'a, Vec<ComponentType>>;
 
     fn get_u32_and_i32_component_vectors(
         archetype: &Archetype,
@@ -1334,8 +1334,8 @@ mod tests {
         let u32_values = u32_read_vec;
         let i32_values = i32_read_vec;
 
-        assert_eq!(&[Some(1_u32), Some(2_u32), Some(3_u32)], &u32_values[..]);
-        assert_eq!(&[Some(1_i32), Some(2_i32), Some(3_i32)], &i32_values[..]);
+        assert_eq!(&[1_u32, 2_u32, 3_u32], &u32_values[..]);
+        assert_eq!(&[1_i32, 2_i32, 3_i32], &i32_values[..]);
     }
 
     #[test]
@@ -1396,8 +1396,8 @@ mod tests {
         let u32_values = u32_read_vec;
         let i32_values = i32_read_vec;
 
-        assert_eq!(&u32_values[..2], &[Some(3_u32), Some(2_u32)]);
-        assert_eq!(&i32_values[..2], &[Some(3_i32), Some(2_i32)]);
+        assert_eq!(&u32_values[..2], &[3_u32, 2_u32]);
+        assert_eq!(&i32_values[..2], &[3_i32, 2_i32]);
     }
 
     #[test]
@@ -1477,9 +1477,9 @@ mod tests {
         let arch_2_u32_values = u32_read_vec;
         let arch_2_i32_values = i32_read_vec;
 
-        assert_eq!([Some(3_u32), Some(2_u32)], arch_2_u32_values[..]);
-        assert_eq!([Some(3_i32), Some(2_i32)], arch_2_i32_values[..]);
-        assert_eq!([Some(1_i32)], arch_3_i32_values[..]);
+        assert_eq!([3_u32, 2_u32], arch_2_u32_values[..]);
+        assert_eq!([3_i32, 2_i32], arch_2_i32_values[..]);
+        assert_eq!([1_i32], arch_3_i32_values[..]);
     }
 
     #[test]
@@ -1543,8 +1543,8 @@ mod tests {
         let u32_values = u32_read_vec;
         let i32_values = i32_read_vec;
 
-        assert_eq!(&u32_values[..2], &[Some(3_u32), Some(2_u32)]);
-        assert_eq!(&i32_values[..2], &[Some(3_i32), Some(2_i32)]);
+        assert_eq!(&u32_values[..2], &[3_u32, 2_u32]);
+        assert_eq!(&i32_values[..2], &[3_i32, 2_i32]);
     }
 
     #[test]
@@ -1653,8 +1653,8 @@ mod tests {
         let component_vec_4_i64 = archetype_4.borrow_component_vec::<i64>().unwrap();
         let value_i64 = component_vec_4_i64.get(0).unwrap();
 
-        assert_eq!(value_usize.unwrap(), 10);
-        assert_eq!(value_i64.unwrap(), 321);
+        assert_eq!(*value_usize, 10);
+        assert_eq!(*value_i64, 321);
     }
 
     fn setup_world_with_three_entities_and_components() -> World {
@@ -1697,7 +1697,7 @@ mod tests {
                     .as_ref()
                     .unwrap()
                     .iter()
-                    .map(|component| component.unwrap())
+                    .map(|component| *component)
             })
             .collect();
         println!("{result:?}");
@@ -1724,7 +1724,7 @@ mod tests {
                     .as_ref()
                     .unwrap()
                     .iter()
-                    .map(|component| component.unwrap())
+                    .map(|component| *component)
             })
             .collect();
         println!("{result:?}");

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -985,7 +985,7 @@ impl Default for World {
 
 fn create_raw_component_vec<ComponentType: Debug + Send + Sync + 'static>() -> Box<dyn ComponentVec>
 {
-    Box::new(RwLock::new(Vec::<ComponentType>::new()))
+    Box::<ComponentVecImpl<ComponentType>>::default()
 }
 
 fn borrow_component_vec<ComponentType: 'static>(

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -536,8 +536,7 @@ pub struct World {
 }
 
 type ReadComponentVec<'a, ComponentType> = Option<RwLockReadGuard<'a, Vec<ComponentType>>>;
-type WriteComponentVec<'a, ComponentType> =
-    Option<RwLockWriteGuard<'a, Vec<ComponentType>>>;
+type WriteComponentVec<'a, ComponentType> = Option<RwLockWriteGuard<'a, Vec<ComponentType>>>;
 type TargetArchSourceTargetIDs = (Option<ArchetypeIndex>, HashSet<TypeId>, HashSet<TypeId>);
 
 enum ArchetypeMutation {
@@ -1297,8 +1296,7 @@ mod tests {
         (world, 2, entity1, entity2, entity3)
     }
 
-    type UnwrappedReadComponentVec<'a, ComponentType> =
-        RwLockReadGuard<'a, Vec<ComponentType>>;
+    type UnwrappedReadComponentVec<'a, ComponentType> = RwLockReadGuard<'a, Vec<ComponentType>>;
 
     fn get_u32_and_i32_component_vectors(
         archetype: &Archetype,
@@ -1648,10 +1646,10 @@ mod tests {
         let archetype_4: &Archetype = world.archetypes.get(4).unwrap();
 
         let component_vec_4_usize = archetype_4.borrow_component_vec::<usize>().unwrap();
-        let value_usize = component_vec_4_usize.get(0).unwrap();
+        let value_usize = component_vec_4_usize.first().unwrap();
 
         let component_vec_4_i64 = archetype_4.borrow_component_vec::<i64>().unwrap();
-        let value_i64 = component_vec_4_i64.get(0).unwrap();
+        let value_i64 = component_vec_4_i64.first().unwrap();
 
         assert_eq!(*value_usize, 10);
         assert_eq!(*value_i64, 321);
@@ -1692,13 +1690,7 @@ mod tests {
         // Collect values from vecs
         let result: HashSet<u32> = vecs_u32
             .iter()
-            .flat_map(|component_vec| {
-                component_vec
-                    .as_ref()
-                    .unwrap()
-                    .iter()
-                    .map(|component| *component)
-            })
+            .flat_map(|component_vec| component_vec.as_ref().unwrap().iter().copied())
             .collect();
         println!("{result:?}");
 
@@ -1719,13 +1711,7 @@ mod tests {
         // Collect values from vecs
         let result: Vec<f32> = vecs_f32
             .iter()
-            .flat_map(|component_vec| {
-                component_vec
-                    .as_ref()
-                    .unwrap()
-                    .iter()
-                    .map(|component| *component)
-            })
+            .flat_map(|component_vec| component_vec.as_ref().unwrap().iter().copied())
             .collect();
         println!("{result:?}");
 

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -1751,9 +1751,7 @@ mod tests {
             while let Some(parameter) =
                 <Read<u32> as SystemParameter>::fetch_parameter(&mut borrowed)
             {
-                if let Some(parameter) = parameter {
-                    result.insert(*parameter);
-                }
+                result.insert(*parameter);
             }
         }
 

--- a/crates/ecs/src/systems/iteration.rs
+++ b/crates/ecs/src/systems/iteration.rs
@@ -277,7 +277,7 @@ mod tests {
 
             unsafe fn fetch_parameter(
                 _borrowed: &mut Self::BorrowedData<'_>,
-            ) -> Option<Option<Self>> {
+            ) -> Option<Self> {
                 unimplemented!()
             }
 

--- a/crates/ecs/src/systems/iteration.rs
+++ b/crates/ecs/src/systems/iteration.rs
@@ -275,9 +275,7 @@ mod tests {
                 unimplemented!()
             }
 
-            unsafe fn fetch_parameter(
-                _borrowed: &mut Self::BorrowedData<'_>,
-            ) -> Option<Self> {
+            unsafe fn fetch_parameter(_borrowed: &mut Self::BorrowedData<'_>) -> Option<Self> {
                 unimplemented!()
             }
 

--- a/crates/ecs/src/systems/mod.rs
+++ b/crates/ecs/src/systems/mod.rs
@@ -339,7 +339,8 @@ impl<Component: Debug + Send + Sync + 'static + Sized> SystemParameter for Read<
         {
             return if let Some(component) = component_vec.get(*component_index) {
                 *component_index += 1;
-                component.as_ref().map(|component| Self {
+                Some(
+                    Self {
                     // The caller is responsible to only use the
                     // returned value when BorrowedData is still in scope.
                     #[allow(trivial_casts)]
@@ -407,9 +408,10 @@ impl<Component: Debug + Send + Sync + 'static + Sized> SystemParameter for Write
         if let Some((ref mut component_index, Some(component_vec))) =
             archetypes.get_mut(*current_archetype)
         {
-            return if let Some(ref mut component) = component_vec.get_mut(*component_index) {
+            return if let Some(component) = component_vec.get_mut(*component_index) {
                 *component_index += 1;
-                component.as_mut().map(|component| Self {
+                Some(
+                    Self {
                     // The caller is responsible to only use the
                     // returned value when BorrowedData is still in scope.
                     #[allow(trivial_casts)]

--- a/crates/ecs/src/systems/mod.rs
+++ b/crates/ecs/src/systems/mod.rs
@@ -339,8 +339,7 @@ impl<Component: Debug + Send + Sync + 'static + Sized> SystemParameter for Read<
         {
             return if let Some(component) = component_vec.get(*component_index) {
                 *component_index += 1;
-                Some(
-                    Self {
+                Some(Self {
                     // The caller is responsible to only use the
                     // returned value when BorrowedData is still in scope.
                     #[allow(trivial_casts)]
@@ -410,8 +409,7 @@ impl<Component: Debug + Send + Sync + 'static + Sized> SystemParameter for Write
         {
             return if let Some(component) = component_vec.get_mut(*component_index) {
                 *component_index += 1;
-                Some(
-                    Self {
+                Some(Self {
                     // The caller is responsible to only use the
                     // returned value when BorrowedData is still in scope.
                     #[allow(trivial_casts)]

--- a/crates/ecs/src/systems/mod.rs
+++ b/crates/ecs/src/systems/mod.rs
@@ -248,7 +248,7 @@ pub trait SystemParameter: Send + Sync + Sized {
     /// Fetches the parameter from the borrowed data for a given entity.
     /// # Safety
     /// The returned value is only guaranteed to be valid until BorrowedData is dropped
-    unsafe fn fetch_parameter(borrowed: &mut Self::BorrowedData<'_>) -> Option<Option<Self>>;
+    unsafe fn fetch_parameter(borrowed: &mut Self::BorrowedData<'_>) -> Option<Self>;
 
     /// A description of what data is accessed and how (read/write).
     fn component_accesses() -> Vec<ComponentAccessDescriptor>;
@@ -333,18 +333,18 @@ impl<Component: Debug + Send + Sync + 'static + Sized> SystemParameter for Read<
         Ok((0, component_vecs))
     }
 
-    unsafe fn fetch_parameter(borrowed: &mut Self::BorrowedData<'_>) -> Option<Option<Self>> {
+    unsafe fn fetch_parameter(borrowed: &mut Self::BorrowedData<'_>) -> Option<Self> {
         let (ref mut current_archetype, archetypes) = borrowed;
         if let Some((component_index, Some(component_vec))) = archetypes.get_mut(*current_archetype)
         {
             return if let Some(component) = component_vec.get(*component_index) {
                 *component_index += 1;
-                Some(component.as_ref().map(|component| Self {
+                component.as_ref().map(|component| Self {
                     // The caller is responsible to only use the
                     // returned value when BorrowedData is still in scope.
                     #[allow(trivial_casts)]
                     output: &*(component as *const Component),
-                }))
+                })
             } else {
                 // End of archetype
                 *current_archetype += 1;
@@ -402,19 +402,19 @@ impl<Component: Debug + Send + Sync + 'static + Sized> SystemParameter for Write
         }))
     }
 
-    unsafe fn fetch_parameter(borrowed: &mut Self::BorrowedData<'_>) -> Option<Option<Self>> {
+    unsafe fn fetch_parameter(borrowed: &mut Self::BorrowedData<'_>) -> Option<Self> {
         let (ref mut current_archetype, archetypes) = borrowed;
         if let Some((ref mut component_index, Some(component_vec))) =
             archetypes.get_mut(*current_archetype)
         {
             return if let Some(ref mut component) = component_vec.get_mut(*component_index) {
                 *component_index += 1;
-                Some(component.as_mut().map(|component| Self {
+                component.as_mut().map(|component| Self {
                     // The caller is responsible to only use the
                     // returned value when BorrowedData is still in scope.
                     #[allow(trivial_casts)]
                     output: &mut *(component as *mut Component),
-                }))
+                })
             } else {
                 // End of archetype
                 *current_archetype += 1;
@@ -520,13 +520,13 @@ impl<'a, P: SystemParameters> SystemParameter for Query<'a, P> {
         Ok(world)
     }
 
-    unsafe fn fetch_parameter(borrowed: &mut Self::BorrowedData<'_>) -> Option<Option<Self>> {
+    unsafe fn fetch_parameter(borrowed: &mut Self::BorrowedData<'_>) -> Option<Self> {
         #[allow(trivial_casts)]
         let world = &*(*borrowed as *const World);
-        Some(Some(Self {
+        Some(Self {
             phantom: PhantomData::default(),
             world,
-        }))
+        })
     }
 
     fn component_accesses() -> Vec<ComponentAccessDescriptor> {
@@ -603,7 +603,7 @@ macro_rules! impl_system_parameter_function {
                     // will still hold a reference to the data in the unlocked component vectors.
                     // In that case, we need to relay on the scheduler to prevent data races.
                     unsafe {
-                        if let ($(Some(Some([<parameter_$parameter>])),)*) = (
+                        if let ($(Some([<parameter_$parameter>]),)*) = (
                             $([<P$parameter>]::fetch_parameter(&mut [<borrowed_$parameter>]),)*
                         ) {
                             return Some(($([<parameter_$parameter>],)*));
@@ -669,13 +669,9 @@ macro_rules! impl_system_parameter_function {
                             while let ($(Some([<parameter_$parameter>]),)*) = (
                                 $([<P$parameter>]::fetch_parameter(&mut self.borrowed.$parameter),)*
                             ) {
-                                if let ($(Some([<parameter_$parameter>]),)*) = (
-                                    $([<parameter_$parameter>],)*
-                                ) {
                                     return Some(($([<parameter_$parameter>],)*));
-                                }
                             }
-                        } else if let (false, $(Some(Some([<parameter_$parameter>])),)*) = (
+                        } else if let (false, $(Some([<parameter_$parameter>]),)*) = (
                             self.iterated_once,
                             $([<P$parameter>]::fetch_parameter(&mut self.borrowed.$parameter),)*
                         ) {


### PR DESCRIPTION
The extra Option wrapper has been removed from ComponentVec and its associated types. All tests pass, the small example programs runs. The n-body simulation runs and profiling still works. 

Please also run these on your system as well, so that we know it really works. Thanks 😄