### PR TITLE
101 extract archetypes module

### DIFF
--- a/crates/ecs/src/archetypes.rs
+++ b/crates/ecs/src/archetypes.rs
@@ -279,6 +279,11 @@ impl Archetype {
 
 impl World {
     pub(super) fn create_entity_in_empty_archetype(&mut self) -> WorldResult<Entity> {
+        if self.archetypes.is_empty() {
+            // Insert the "empty entity archetype" if not already created.
+            self.archetypes.push(Archetype::default());
+        }
+
         let entity_id = self.entities.len();
         let entity = Entity { id: entity_id };
         self.entities.push(entity);

--- a/crates/ecs/src/archetypes.rs
+++ b/crates/ecs/src/archetypes.rs
@@ -1,0 +1,989 @@
+use crate::systems::ComponentIndex;
+use crate::{
+    get_mut_at_two_indices, ArchetypeIndex, Entity, NoHashHashMap, ReadComponentVec, World,
+    WorldError, WorldResult, WriteComponentVec,
+};
+use fnv::{FnvHashMap, FnvHashSet};
+use std::any;
+use std::any::{Any, TypeId};
+use std::fmt::Debug;
+use std::sync::{RwLock, TryLockError};
+use thiserror::Error;
+
+type ComponentVecImpl<ComponentType> = RwLock<Vec<ComponentType>>;
+
+trait ComponentVec: Debug + Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    /// Returns the type stored in the component vector.
+    fn stored_type(&self) -> TypeId;
+    /// Returns the number of components stored in the component vector.
+    fn len(&self) -> usize;
+    /// Removes the entity from the component vector.
+    fn remove(&self, index: usize);
+    /// Removes a component and pushes it to another
+    /// archetypes component vector of the same data type.
+    fn move_element(&self, source_index: usize, target_arch: &mut Archetype)
+        -> ArchetypeResult<()>;
+}
+
+impl<T: Debug + Send + Sync + 'static> ComponentVec for ComponentVecImpl<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn stored_type(&self) -> TypeId {
+        TypeId::of::<T>()
+    }
+
+    fn len(&self) -> usize {
+        Vec::len(&self.read().expect("Lock is poisoned"))
+    }
+
+    fn remove(&self, index: usize) {
+        self.write().expect("Lock is poisoned").swap_remove(index);
+    }
+
+    fn move_element(
+        &self,
+        source_index: usize,
+        target_arch: &mut Archetype,
+    ) -> ArchetypeResult<()> {
+        let value = self
+            .write()
+            .expect("Lock is poisoned")
+            .swap_remove(source_index);
+
+        if !target_arch.contains_component_type::<T>() {
+            target_arch.add_component_vec::<T>()
+        }
+
+        let target_vec = target_arch
+            .component_typeid_to_component_vec
+            .get(&TypeId::of::<T>())
+            .expect("component vec has been added if it was not there previously")
+            .as_ref();
+
+        let mut component_vec = borrow_component_vec_mut::<T>(target_vec)
+            .ok_or(ArchetypeError::CouldNotBorrowComponentVec(TypeId::of::<T>()))?;
+
+        component_vec.push(value);
+
+        Ok(())
+    }
+}
+
+fn create_raw_component_vec<ComponentType: Debug + Send + Sync + 'static>() -> Box<dyn ComponentVec>
+{
+    Box::<ComponentVecImpl<ComponentType>>::default()
+}
+
+fn borrow_component_vec<ComponentType: 'static>(
+    component_vec: &dyn ComponentVec,
+) -> ReadComponentVec<ComponentType> {
+    if let Some(component_vec) = component_vec
+        .as_any()
+        .downcast_ref::<ComponentVecImpl<ComponentType>>()
+    {
+        // This method should only be called once the scheduler has verified
+        // that component access can be done without contention.
+        // Panicking helps us detect errors in the scheduling algorithm more quickly.
+        return match component_vec.try_read() {
+            Ok(component_vec) => Some(component_vec),
+            Err(TryLockError::WouldBlock) => panic_locked_component_vec::<ComponentType>(),
+            Err(TryLockError::Poisoned(_)) => panic!("Lock should not be poisoned!"),
+        };
+    }
+    None
+}
+
+fn panic_locked_component_vec<ComponentType: 'static>() -> ! {
+    let component_type_name = any::type_name::<ComponentType>();
+    panic!(
+        "Lock of ComponentVec<{}> is already taken!",
+        component_type_name
+    )
+}
+
+fn borrow_component_vec_mut<ComponentType: 'static>(
+    component_vec: &dyn ComponentVec,
+) -> WriteComponentVec<ComponentType> {
+    if let Some(component_vec) = component_vec
+        .as_any()
+        .downcast_ref::<ComponentVecImpl<ComponentType>>()
+    {
+        // This method should only be called once the scheduler has verified
+        // that component access can be done without contention.
+        // Panicking helps us detect errors in the scheduling algorithm more quickly.
+        return match component_vec.try_write() {
+            Ok(component_vec) => Some(component_vec),
+            Err(TryLockError::WouldBlock) => panic_locked_component_vec::<ComponentType>(),
+            Err(TryLockError::Poisoned(_)) => panic!("Lock should not be poisoned!"),
+        };
+    }
+    None
+}
+
+/// An error occurred during a archetype operation.
+#[derive(Error, Debug)]
+pub enum ArchetypeError {
+    /// Could not find component index of entity
+    #[error("could not find component index of entity: {0:?}")]
+    MissingEntityIndex(Entity),
+
+    /// Could not borrow component vec
+    #[error("could not borrow component vec of type: {0:?}")]
+    CouldNotBorrowComponentVec(TypeId),
+
+    /// Component vec not found for type id
+    #[error("component vec not found for type id: {0:?}")]
+    MissingComponentType(TypeId),
+
+    /// Archetype already contains entity
+    #[error("archetype already contains entity: {0:?}")]
+    EntityAlreadyExists(Entity),
+}
+
+/// Whether a archetype operation succeeded.
+pub type ArchetypeResult<T, E = ArchetypeError> = Result<T, E>;
+
+/// Stores components associated with entity ids.
+#[derive(Debug, Default)]
+pub struct Archetype {
+    component_typeid_to_component_vec: FnvHashMap<TypeId, Box<dyn ComponentVec>>,
+    entity_to_component_index: NoHashHashMap<Entity, ComponentIndex>,
+    entity_order: Vec<Entity>,
+}
+
+/// Newly created entities with no components on them, are placed in this archetype.
+const EMPTY_ENTITY_ARCHETYPE_INDEX: ArchetypeIndex = 0;
+
+type TargetArchSourceTargetIDs = (
+    Option<ArchetypeIndex>,
+    FnvHashSet<TypeId>,
+    FnvHashSet<TypeId>,
+);
+
+enum ArchetypeMutation {
+    Removal(Entity),
+    Addition(Entity),
+}
+
+impl Archetype {
+    /// Gets the [`ComponentIndex`] of a given [`Entity`] in this archetype.
+    pub fn get_component_index_of(&self, entity: Entity) -> Option<ComponentIndex> {
+        self.entity_to_component_index.get(&entity).cloned()
+    }
+
+    pub fn read_component_vec<ComponentType: 'static>(&self) -> ReadComponentVec<ComponentType> {
+        let component_vec_u32 = self
+            .component_typeid_to_component_vec
+            .get(&TypeId::of::<ComponentType>())?
+            .as_ref();
+        borrow_component_vec::<ComponentType>(component_vec_u32)
+    }
+
+    /// Adds an `entity_id` to keep track of and store components for.
+    ///
+    /// Returns error if entity with `id` has been stored previously.
+    fn store_entity(&mut self, entity: Entity) -> ArchetypeResult<()> {
+        let entity_index = self.entity_to_component_index.len();
+
+        match self.entity_to_component_index.insert(entity, entity_index) {
+            None => {
+                self.entity_order.push(entity);
+                Ok(())
+            }
+            Some(_) => Err(ArchetypeError::EntityAlreadyExists(entity)),
+        }
+    }
+
+    /// Returns a `ReadComponentVec` with the specified generic type `ComponentType` if it is stored.
+    pub(super) fn borrow_component_vec<ComponentType: Debug + Send + Sync + 'static>(
+        &self,
+    ) -> ReadComponentVec<ComponentType> {
+        let component_typeid = TypeId::of::<ComponentType>();
+        self.component_typeid_to_component_vec
+            .get(&component_typeid)
+            .map(Box::as_ref)
+            .and_then(borrow_component_vec)
+    }
+
+    /// Returns a `WriteComponentVec` with the specified generic type `ComponentType` if it is stored.
+    pub(super) fn borrow_component_vec_mut<ComponentType: Debug + Send + Sync + 'static>(
+        &self,
+    ) -> WriteComponentVec<ComponentType> {
+        let component_typeid = TypeId::of::<ComponentType>();
+        self.component_typeid_to_component_vec
+            .get(&component_typeid)
+            .map(Box::as_ref)
+            .and_then(borrow_component_vec_mut)
+    }
+
+    /// Adds a component of type `ComponentType` to archetype.
+    fn add_component<ComponentType: Debug + Send + Sync + 'static>(
+        &mut self,
+        component: ComponentType,
+    ) -> ArchetypeResult<()> {
+        let mut component_vec = self.borrow_component_vec_mut::<ComponentType>().ok_or(
+            ArchetypeError::CouldNotBorrowComponentVec(TypeId::of::<ComponentType>()),
+        )?;
+        component_vec.push(component);
+
+        Ok(())
+    }
+
+    /// Adds a component vec of type `ComponentType` if no such vec already exists.
+    ///
+    /// This function is idempotent when trying to add the same `ComponentType` multiple times.
+    fn add_component_vec<ComponentType: Debug + Send + Sync + 'static>(&mut self) {
+        if !self.contains_component_type::<ComponentType>() {
+            let raw_component_vec = create_raw_component_vec::<ComponentType>();
+
+            let component_typeid = TypeId::of::<ComponentType>();
+            self.component_typeid_to_component_vec
+                .insert(component_typeid, raw_component_vec);
+        }
+    }
+
+    /// Returns `true` if the archetype stores components of type ComponentType.
+    fn contains_component_type<ComponentType: Debug + Send + Sync + 'static>(&self) -> bool {
+        self.component_typeid_to_component_vec
+            .contains_key(&TypeId::of::<ComponentType>())
+    }
+
+    // todo(#101): make private
+    fn update_source_archetype_after_entity_move(&mut self, entity: Entity) {
+        let source_component_vec_idx = *self.entity_to_component_index.get(&entity).expect(
+            "Entity should yield a component index
+             in archetype since the the relevant archetype
+              was fetched from the entity itself.",
+        );
+        // Update old archetypes component vec index after moving entity
+        if let Some(&swapped_entity) = self.entity_order.last() {
+            self.entity_to_component_index
+                .insert(swapped_entity, source_component_vec_idx);
+        }
+        // Remove entity component index existing in its old archetype
+        self.entity_order.swap_remove(source_component_vec_idx);
+
+        self.entity_to_component_index.remove(&entity);
+    }
+    fn component_types(&self) -> FnvHashSet<TypeId> {
+        self.component_typeid_to_component_vec
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    pub fn get_entity(&self, component_index: ComponentIndex) -> Option<Entity> {
+        self.entity_order.get(component_index).cloned()
+    }
+}
+
+impl World {
+    pub(super) fn create_entity_in_empty_archetype(&mut self) -> WorldResult<Entity> {
+        let entity_id = self.entities.len();
+        let entity = Entity { id: entity_id };
+        self.entities.push(entity);
+        self.store_entity_in_archetype(entity, EMPTY_ENTITY_ARCHETYPE_INDEX)?;
+        Ok(entity)
+    }
+
+    /// Returns the archetype index of the archetype that contains all
+    /// components types that the entity is tied to +- the generic type
+    /// supplied to the function given Addition/ Removal enum status.
+    /// `None` is returned if no archetype containing only the sought after component types exist.
+    /// The type ids contained within the archetype the entity is existing in and the type ids for
+    /// sought archetype are also returned.
+    ///
+    /// Set mutation to ArchetypeMutation::Addition(entity)/ ArchetypeMutation::Removal(entity)
+    /// depending on if the supplied generic type should be added to or
+    /// removed from the specified entity.
+    ///
+    /// For example call world.find_target_archetype::<u32>(ArchetypeMutation::Removal(entity))
+    /// to fetch the archetype index of the archetype
+    /// containing all component types except u32 that the entity is tied to.
+    ///
+    /// world.find_target_archetype::<u32>(ArchetypeMutation::Addition(entity))
+    /// would return the archetype index of the
+    /// archetype containing all component types that the entity is tied to with the addition
+    /// of u32.
+    fn find_target_archetype<ComponentType: Debug + Send + Sync + 'static>(
+        &self,
+        mutation: ArchetypeMutation,
+    ) -> WorldResult<TargetArchSourceTargetIDs> {
+        let source_archetype_type_ids: FnvHashSet<TypeId>;
+
+        let mut target_archetype_type_ids: FnvHashSet<TypeId>;
+
+        match mutation {
+            ArchetypeMutation::Removal(nested_entity) => {
+                let source_archetype = self.get_archetype_of_entity(nested_entity)?;
+
+                source_archetype_type_ids = source_archetype.component_types();
+
+                target_archetype_type_ids = source_archetype_type_ids.clone();
+
+                if !target_archetype_type_ids.remove(&TypeId::of::<ComponentType>()) {
+                    return Err(WorldError::ComponentTypeNotPresentForEntity(
+                        nested_entity,
+                        TypeId::of::<ComponentType>(),
+                    ));
+                }
+            }
+
+            ArchetypeMutation::Addition(nested_entity) => {
+                let source_archetype = self.get_archetype_of_entity(nested_entity)?;
+
+                source_archetype_type_ids = source_archetype.component_types();
+
+                target_archetype_type_ids = source_archetype_type_ids.clone();
+
+                target_archetype_type_ids.insert(TypeId::of::<ComponentType>());
+
+                if source_archetype_type_ids.contains(&TypeId::of::<ComponentType>()) {
+                    return Err(WorldError::ComponentTypeAlreadyExistsForEntity(
+                        nested_entity,
+                        TypeId::of::<ComponentType>(),
+                    ));
+                }
+            }
+        }
+
+        let target_archetype_type_ids_vec: Vec<TypeId> = target_archetype_type_ids
+            .iter()
+            .cloned()
+            .collect::<Vec<TypeId>>();
+
+        let maybe_target_archetype =
+            self.get_exactly_matching_archetype(&target_archetype_type_ids_vec);
+
+        Ok((
+            maybe_target_archetype,
+            source_archetype_type_ids,
+            target_archetype_type_ids,
+        ))
+    }
+
+    fn move_entity_components_between_archetypes(
+        &mut self,
+        entity: Entity,
+        target_archetype_idx: ArchetypeIndex,
+        components_to_move: FnvHashSet<TypeId>,
+    ) -> WorldResult<()> {
+        let source_archetype_index = *self
+            .entity_to_archetype_index
+            .get(&entity)
+            .ok_or(WorldError::EntityDoesNotExist(entity))?;
+
+        let (source_archetype, target_archetype) = get_mut_at_two_indices(
+            source_archetype_index,
+            target_archetype_idx,
+            &mut self.archetypes,
+        );
+
+        let source_component_idx = *source_archetype
+            .entity_to_component_index
+            .get(&entity)
+            .expect("Entity should have a component index tied to it since it is already established to be existing within the archetype");
+
+        for type_id in components_to_move {
+            let source_component_vec = source_archetype
+                .component_typeid_to_component_vec
+                .get(&type_id)
+                .expect(
+                    "Type that tried to be fetched should exist
+                     in archetype since types are fetched from this archetype originally.",
+                );
+
+            source_component_vec
+                .move_element(source_component_idx, target_archetype)
+                .map_err(WorldError::CouldNotMoveComponent)?;
+        }
+
+        target_archetype
+            .store_entity(entity)
+            .map_err(WorldError::CouldNotMoveComponent)?;
+
+        self.entity_to_archetype_index
+            .insert(entity, target_archetype_idx);
+
+        Ok(())
+    }
+
+    fn move_entity_components_to_new_archetype(
+        &mut self,
+        entity: Entity,
+        components_to_move: FnvHashSet<TypeId>,
+    ) -> WorldResult<ArchetypeIndex> {
+        let new_archetype = Archetype::default();
+        let new_archetype_index: ArchetypeIndex = self.archetypes.len();
+        self.archetypes.push(new_archetype);
+
+        for component_type in &components_to_move {
+            self.component_typeid_to_archetype_indices
+                .get_mut(component_type)
+                .expect("Type ID should exist for previously existing types")
+                .insert(new_archetype_index);
+        }
+
+        self.move_entity_components_between_archetypes(
+            entity,
+            new_archetype_index,
+            components_to_move,
+        )?;
+
+        Ok(new_archetype_index)
+    }
+
+    pub(crate) fn add_component_to_entity_and_move_archetype<
+        ComponentType: Debug + Send + Sync + 'static,
+    >(
+        &mut self,
+        entity: Entity,
+        component: ComponentType,
+    ) -> WorldResult<()> {
+        let source_archetype_index = *self
+            .entity_to_archetype_index
+            .get(&entity)
+            .ok_or(WorldError::EntityDoesNotExist(entity))?;
+
+        let add = ArchetypeMutation::Addition(entity);
+
+        let (target_archetype_exists, source_type_ids, target_type_ids) =
+            self.find_target_archetype::<ComponentType>(add)?;
+
+        match target_archetype_exists {
+            Some(target_archetype_idx) => {
+                self.move_entity_components_between_archetypes(
+                    entity,
+                    target_archetype_idx,
+                    source_type_ids,
+                )?;
+
+                let target_archetype = self.archetypes
+                    .get_mut(target_archetype_idx)
+                    .expect("Archetype should exist since it was the requirement for entering this matching case");
+                target_archetype
+                    .add_component(component)
+                    .map_err(WorldError::CouldNotAddComponent)?;
+            }
+            None => {
+                let target_archetype_idx =
+                    self.move_entity_components_to_new_archetype(entity, source_type_ids)?;
+
+                let mut target_type_ids_vec: Vec<TypeId> = target_type_ids.into_iter().collect();
+
+                // Sort the vec since order of elements in vec matter when matching keys.
+                // Sorting the key is done both when inserting and reading from this hashmap to
+                // maintain consistent behaviour.
+                target_type_ids_vec.sort();
+                self.component_typeids_set_to_archetype_index
+                    .insert(target_type_ids_vec, target_archetype_idx);
+
+                let target_archetype = self
+                    .archetypes
+                    .get_mut(target_archetype_idx)
+                    .expect("This should be added in the previous function call");
+
+                // Handle incoming component
+                target_archetype.add_component_vec::<ComponentType>();
+                let archetype_indices = self
+                    .component_typeid_to_archetype_indices
+                    .entry(TypeId::of::<ComponentType>())
+                    .or_default();
+                archetype_indices.insert(target_archetype_idx);
+
+                target_archetype
+                    .add_component(component)
+                    .map_err(WorldError::CouldNotAddComponent)?;
+            }
+        }
+
+        let source_archetype = self
+            .archetypes
+            .get_mut(source_archetype_index)
+            .expect("Source archetype has already been fetched previously");
+
+        source_archetype.update_source_archetype_after_entity_move(entity);
+
+        Ok(())
+    }
+
+    pub(super) fn remove_component_type_from_entity<
+        ComponentType: Debug + Send + Sync + 'static,
+    >(
+        &mut self,
+        entity: Entity,
+    ) -> WorldResult<()> {
+        let source_archetype_index = *self
+            .entity_to_archetype_index
+            .get(&entity)
+            .ok_or(WorldError::EntityDoesNotExist(entity))?;
+
+        let removal = ArchetypeMutation::Removal(entity);
+        let (target_archetype_exists, _, target_type_ids) =
+            self.find_target_archetype::<ComponentType>(removal)?;
+
+        match target_archetype_exists {
+            Some(target_archetype_idx) => {
+                self.move_entity_components_between_archetypes(
+                    entity,
+                    target_archetype_idx,
+                    target_type_ids,
+                )?;
+            }
+            None => {
+                let mut target_type_ids_vec: Vec<TypeId> =
+                    target_type_ids.iter().cloned().collect();
+                let target_archetype_idx =
+                    self.move_entity_components_to_new_archetype(entity, target_type_ids)?;
+
+                // Sort the vec since order of elements in vec matter when matching keys.
+                // Sorting the key is done both when inserting and reading from this hashmap to
+                // maintain consistent behaviour.
+                target_type_ids_vec.sort();
+                self.component_typeids_set_to_archetype_index
+                    .insert(target_type_ids_vec, target_archetype_idx);
+            }
+        }
+
+        let source_archetype = self
+            .archetypes
+            .get_mut(source_archetype_index)
+            .ok_or(WorldError::ArchetypeDoesNotExist(source_archetype_index))?;
+
+        let source_component_vec = source_archetype
+            .component_typeid_to_component_vec
+            .get(&TypeId::of::<ComponentType>())
+            .expect(
+                "Type that tried to be fetched should exist
+                         in archetype since types are fetched from this archetype originally.",
+            );
+
+        let source_component_vec_idx = *source_archetype.entity_to_component_index
+            .get(&entity)
+            .expect("Entity should have a component index tied to it since it is already established to be existing within the archetype");
+
+        source_component_vec.remove(source_component_vec_idx);
+
+        source_archetype.update_source_archetype_after_entity_move(entity);
+
+        Ok(())
+    }
+
+    fn store_entity_in_archetype(
+        &mut self,
+        entity: Entity,
+        archetype_index: ArchetypeIndex,
+    ) -> WorldResult<()> {
+        let archetype = self
+            .archetypes
+            .get_mut(archetype_index)
+            .ok_or(WorldError::ArchetypeDoesNotExist(archetype_index))?;
+
+        archetype
+            .store_entity(entity)
+            .map_err(WorldError::CouldNotAddComponent)?;
+
+        self.entity_to_archetype_index
+            .insert(entity, archetype_index);
+        Ok(())
+    }
+
+    pub(super) fn get_archetypes(
+        &self,
+        archetype_indices: &[ArchetypeIndex],
+    ) -> WorldResult<Vec<&Archetype>> {
+        let archetypes: Result<Vec<_>, _> = archetype_indices
+            .iter()
+            .map(|&archetype_index| {
+                self.archetypes
+                    .get(archetype_index)
+                    .ok_or(WorldError::ArchetypeDoesNotExist(archetype_index))
+            })
+            .collect();
+        archetypes
+    }
+
+    fn get_exactly_matching_archetype(
+        &self,
+        component_type_ids: &Vec<TypeId>,
+    ) -> Option<ArchetypeIndex> {
+        if component_type_ids.is_empty() {
+            return Some(EMPTY_ENTITY_ARCHETYPE_INDEX);
+        }
+        let mut sorted_component_type_ids = component_type_ids.clone();
+        // Sort the vec since order of elements in vec matter when matching keys.
+        // Sorting the key is done both when inserting and reading from this hashmap to
+        // maintain consistent behaviour.
+        sorted_component_type_ids.sort();
+        self.component_typeids_set_to_archetype_index
+            .get(&sorted_component_type_ids)
+            .copied()
+    }
+
+    fn get_archetype_of_entity(&self, entity: Entity) -> WorldResult<&Archetype> {
+        let source_archetype_index = *self
+            .entity_to_archetype_index
+            .get(&entity)
+            .ok_or(WorldError::EntityDoesNotExist(entity))?;
+
+        let source_archetype = self
+            .archetypes
+            .get(source_archetype_index)
+            .ok_or(WorldError::ArchetypeDoesNotExist(source_archetype_index))?;
+
+        Ok(source_archetype)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use test_log::test;
+
+    #[derive(Debug)]
+    struct A;
+
+    #[derive(Debug)]
+    struct B;
+
+    #[derive(Debug)]
+    struct C;
+
+    trait BorrowComponentVecsWithSignature {
+        fn borrow_component_vecs_with_signature<ComponentType: Debug + Send + Sync + 'static>(
+            &self,
+            signature: &[TypeId],
+        ) -> WorldResult<Vec<ReadComponentVec<ComponentType>>>;
+
+        fn borrow_component_vecs_with_signature_mut<ComponentType: Debug + Send + Sync + 'static>(
+            &self,
+            signature: &[TypeId],
+        ) -> WorldResult<Vec<WriteComponentVec<ComponentType>>>;
+    }
+
+    impl BorrowComponentVecsWithSignature for World {
+        fn borrow_component_vecs_with_signature<ComponentType: Debug + Send + Sync + 'static>(
+            &self,
+            signature: &[TypeId],
+        ) -> WorldResult<Vec<ReadComponentVec<ComponentType>>> {
+            let archetype_indices: Vec<_> =
+                self.get_archetype_indices(signature).into_iter().collect();
+            self.borrow_component_vecs(&archetype_indices)
+        }
+
+        fn borrow_component_vecs_with_signature_mut<
+            ComponentType: Debug + Send + Sync + 'static,
+        >(
+            &self,
+            signature: &[TypeId],
+        ) -> WorldResult<Vec<WriteComponentVec<ComponentType>>> {
+            let archetype_indices: Vec<_> =
+                self.get_archetype_indices(signature).into_iter().collect();
+            self.borrow_component_vecs_mut(&archetype_indices)
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Lock of ComponentVec<ecs::archetypes::tests::A> is already taken!")]
+    fn world_panics_when_trying_to_mutably_borrow_same_components_twice() {
+        let mut world = World::default();
+
+        let entity = world.create_new_entity().unwrap();
+        world.add_component_to_entity(entity, A).unwrap();
+
+        let _first = world
+            .borrow_component_vecs_with_signature_mut::<A>(&[TypeId::of::<A>()])
+            .unwrap();
+        let _second = world
+            .borrow_component_vecs_with_signature_mut::<A>(&[TypeId::of::<A>()])
+            .unwrap();
+    }
+
+    #[test]
+    fn world_doesnt_panic_when_mutably_borrowing_components_after_dropping_previous_mutable_borrow()
+    {
+        let mut world = World::default();
+
+        let entity = world.create_new_entity().unwrap();
+
+        world.add_component_to_entity(entity, A).unwrap();
+
+        let first = world.borrow_component_vecs_with_signature_mut::<A>(&[TypeId::of::<A>()]);
+        drop(first);
+        let _second = world.borrow_component_vecs_with_signature_mut::<A>(&[TypeId::of::<A>()]);
+    }
+
+    #[test]
+    fn world_does_not_panic_when_trying_to_immutably_borrow_same_components_twice() {
+        let mut world = World::default();
+
+        let entity = world.create_new_entity().unwrap();
+
+        world.add_component_to_entity(entity, A).unwrap();
+
+        let _first = world.borrow_component_vecs_with_signature::<A>(&[TypeId::of::<A>()]);
+        let _second = world.borrow_component_vecs_with_signature::<A>(&[TypeId::of::<A>()]);
+    }
+
+    fn setup_world_with_3_entities_with_u32_and_i32_components(
+    ) -> (World, ArchetypeIndex, Entity, Entity, Entity) {
+        let mut world = World::default();
+
+        let entity1 = world.create_new_entity().unwrap();
+        let entity2 = world.create_new_entity().unwrap();
+        let entity3 = world.create_new_entity().unwrap();
+
+        world.add_component_to_entity(entity1, 1_u32).unwrap();
+        world.add_component_to_entity(entity1, 1_i32).unwrap();
+
+        world.add_component_to_entity(entity2, 2_u32).unwrap();
+        world.add_component_to_entity(entity2, 2_i32).unwrap();
+
+        world.add_component_to_entity(entity3, 3_u32).unwrap();
+        world.add_component_to_entity(entity3, 3_i32).unwrap();
+
+        // All entities in archetype with index 2 now
+        (world, 2, entity1, entity2, entity3)
+    }
+
+    #[test]
+    fn type_id_order_does_not_affect_fetching_of_correct_archetype() {
+        let (world, _, _, _, _) = setup_world_with_3_entities_with_u32_and_i32_components();
+
+        let type_vector_1 = vec![TypeId::of::<u32>(), TypeId::of::<i32>()];
+        let type_vector_2 = vec![TypeId::of::<i32>(), TypeId::of::<u32>()];
+        let result_1 = world
+            .get_exactly_matching_archetype(&type_vector_1)
+            .unwrap();
+        let result_2 = world
+            .get_exactly_matching_archetype(&type_vector_2)
+            .unwrap();
+
+        assert_eq!(result_1, result_2);
+    }
+
+    #[test]
+    fn entities_are_in_expected_order_according_to_when_components_were_added() {
+        let (world, relevant_archetype_index, entity1, entity2, entity3) =
+            setup_world_with_3_entities_with_u32_and_i32_components();
+
+        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+
+        assert_eq!(archetype.entity_order, vec![entity1, entity2, entity3]);
+    }
+
+    #[test]
+    fn entity_order_swap_index_after_entity_has_been_moved_by_addition() {
+        let (mut world, relevant_archetype_index, entity1, entity2, entity3) =
+            setup_world_with_3_entities_with_u32_and_i32_components();
+
+        // Add component to entity1 causing it to move to Arch_3
+        world.add_component_to_entity(entity1, 1_usize).unwrap();
+
+        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+
+        assert_eq!(archetype.entity_order, vec![entity3, entity2]);
+    }
+
+    #[test]
+    fn entity_order_swap_index_after_entity_has_been_moved_by_removal() {
+        let (mut world, relevant_archetype_index, entity1, entity2, entity3) =
+            setup_world_with_3_entities_with_u32_and_i32_components();
+
+        // Add component to entity1 causing it to move to Arch_3
+        world
+            .remove_component_type_from_entity::<u32>(entity1)
+            .unwrap();
+
+        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+
+        assert_eq!(archetype.entity_order, vec![entity3, entity2]);
+    }
+
+    #[test]
+    fn entity_to_component_index_gives_expected_values_after_addition() {
+        let (world, relevant_archetype_index, entity1, entity2, entity3) =
+            setup_world_with_3_entities_with_u32_and_i32_components();
+
+        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+
+        let entity1_component_index = *archetype.entity_to_component_index.get(&entity1).unwrap();
+        let entity2_component_index = *archetype.entity_to_component_index.get(&entity2).unwrap();
+        let entity3_component_index = *archetype.entity_to_component_index.get(&entity3).unwrap();
+
+        assert_eq!(entity1_component_index, 0);
+        assert_eq!(entity2_component_index, 1);
+        assert_eq!(entity3_component_index, 2);
+    }
+
+    #[test]
+    fn entity_to_component_index_is_updated_after_move_by_removal() {
+        let (mut world, relevant_archetype_index, entity1, entity2, entity3) =
+            setup_world_with_3_entities_with_u32_and_i32_components();
+
+        // Add component to entity1 causing it to move to Arch_3
+        world
+            .remove_component_type_from_entity::<u32>(entity1)
+            .unwrap();
+
+        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+
+        let entity1_component_index = archetype.entity_to_component_index.get(&entity1);
+        let entity2_component_index = archetype.entity_to_component_index.get(&entity2);
+        let entity3_component_index = archetype.entity_to_component_index.get(&entity3);
+        assert!(entity1_component_index.is_none());
+        assert_eq!(entity2_component_index, Some(&1));
+        assert_eq!(entity3_component_index, Some(&0));
+    }
+
+    #[test]
+    fn entity_to_component_index_is_updated_after_move_by_addition() {
+        let (mut world, relevant_archetype_index, entity1, entity2, entity3) =
+            setup_world_with_3_entities_with_u32_and_i32_components();
+
+        // Add component to entity1 causing it to move to Arch_3
+        world.add_component_to_entity(entity1, 1_usize).unwrap();
+
+        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+
+        let entity1_component_index = archetype.entity_to_component_index.get(&entity1);
+        let entity2_component_index = archetype.entity_to_component_index.get(&entity2);
+        let entity3_component_index = archetype.entity_to_component_index.get(&entity3);
+        assert!(entity1_component_index.is_none());
+        assert_eq!(entity2_component_index, Some(&1));
+        assert_eq!(entity3_component_index, Some(&0));
+    }
+
+    #[test]
+    fn entity_to_component_index_gives_expected_values_after_removal() {
+        let (mut world, relevant_archetype_index, entity1, entity2, entity3) =
+            setup_world_with_3_entities_with_u32_and_i32_components();
+
+        // Add component to entity1 causing it to move to Arch_3
+        world
+            .remove_component_type_from_entity::<u32>(entity1)
+            .unwrap();
+
+        let archetype_1 = world.archetypes.get(3).unwrap();
+        let archetype_2 = world.archetypes.get(relevant_archetype_index).unwrap();
+
+        let arch_1_entity1_component_index = archetype_1.entity_to_component_index.get(&entity1);
+
+        let arch_2_entity1_component_index = archetype_2.entity_to_component_index.get(&entity1);
+        let arch_2_entity2_component_index = archetype_2.entity_to_component_index.get(&entity2);
+        let arch_2_entity3_component_index = archetype_2.entity_to_component_index.get(&entity3);
+
+        assert_eq!(arch_1_entity1_component_index, Some(&0));
+        assert_eq!(arch_2_entity1_component_index, None);
+        assert_eq!(arch_2_entity2_component_index, Some(&1));
+        assert_eq!(arch_2_entity3_component_index, Some(&0));
+    }
+
+    #[test]
+    fn borrow_with_signature_returns_expected_values() {
+        // Arrange
+        let (world, _, _, _, _) = setup_world_with_3_entities_with_u32_and_i32_components();
+
+        // Act
+        // Borrow all vecs containing u32 from archetypes have the signature u32
+        let vecs_u32 = world
+            .borrow_component_vecs_with_signature::<u32>(&[TypeId::of::<u32>()])
+            .unwrap();
+        eprintln!("vecs_u32 = {vecs_u32:#?}");
+        // Assert
+        // Collect values from vecs
+        let result: HashSet<u32> = vecs_u32
+            .iter()
+            .flat_map(|component_vec| component_vec.as_ref().unwrap().iter().copied())
+            .collect();
+        println!("{result:?}");
+
+        assert_eq!(result, HashSet::from([1, 2, 3]))
+    }
+
+    #[test]
+    fn borrowing_non_existent_component_returns_empty_vec() {
+        // Arrange
+        let (world, _, _, _, _) = setup_world_with_3_entities_with_u32_and_i32_components();
+
+        // Act
+        let vecs_f32 = world
+            .borrow_component_vecs_with_signature::<f32>(&[TypeId::of::<f32>()])
+            .unwrap();
+        eprintln!("vecs_f32 = {vecs_f32:#?}");
+        // Assert
+        // Collect values from vecs
+        let result: Vec<f32> = vecs_f32
+            .iter()
+            .flat_map(|component_vec| component_vec.as_ref().unwrap().iter().copied())
+            .collect();
+        println!("{result:?}");
+
+        assert_eq!(result, vec![])
+    }
+
+    #[test]
+    #[should_panic]
+    fn borrowing_component_vec_twice_from_archetype_causes_panic() {
+        let mut archetype = Archetype::default();
+        archetype.add_component_vec::<u32>();
+
+        let borrow_1 = archetype.borrow_component_vec_mut::<u32>();
+        let borrow_2 = archetype.borrow_component_vec_mut::<u32>();
+
+        // Drop after both have been borrowed to make sure they both live this long.
+        drop(borrow_1);
+        drop(borrow_2);
+    }
+
+    #[test]
+    fn borrowing_component_vec_after_reference_has_been_dropped_does_not_cause_panic() {
+        let mut archetype = Archetype::default();
+        archetype.add_component_vec::<u32>();
+
+        let borrow_1 = archetype.borrow_component_vec_mut::<u32>();
+        drop(borrow_1);
+
+        let borrow_2 = archetype.borrow_component_vec_mut::<u32>();
+        drop(borrow_2);
+    }
+
+    #[test]
+    fn borrowing_two_different_component_vecs_from_archetype_does_not_cause_panic() {
+        let mut archetype = Archetype::default();
+        archetype.add_component_vec::<u32>();
+        archetype.add_component_vec::<u64>();
+
+        let a = archetype.borrow_component_vec_mut::<u32>();
+        let b = archetype.borrow_component_vec_mut::<u64>();
+
+        // Drop after both have been borrowed to make sure they both live this long.
+        drop(a);
+        drop(b);
+    }
+
+    #[test]
+    fn get_entity_from_component_index() {
+        let (world, _, _, _, _) = setup_world_with_3_entities_with_u32_and_i32_components();
+
+        //Get the first entity added to world
+        let comp_entity = world.entities.get(0).copied().unwrap();
+
+        //Get the archetype index of the archetype that stores that entity
+        let archetype = world.get_archetype_of_entity(comp_entity).unwrap();
+
+        //Get the first entity stored in that archetype, check that it is the same
+        let get_entity = archetype.get_entity(0).unwrap();
+
+        assert_eq!(comp_entity, get_entity);
+    }
+}

--- a/crates/ecs/src/archetypes.rs
+++ b/crates/ecs/src/archetypes.rs
@@ -448,7 +448,7 @@ impl World {
         Ok(new_archetype_index)
     }
 
-    pub(crate) fn add_component_to_entity<ComponentType>(
+    pub(super) fn add_component_to_entity<ComponentType>(
         &mut self,
         entity: Entity,
         component: ComponentType,
@@ -515,7 +515,7 @@ impl World {
         Ok(())
     }
 
-    pub(crate) fn remove_component_type_from_entity<ComponentType>(
+    pub(super) fn remove_component_type_from_entity<ComponentType>(
         &mut self,
         entity: Entity,
     ) -> WorldResult<()>

--- a/crates/ecs/src/archetypes.rs
+++ b/crates/ecs/src/archetypes.rs
@@ -489,14 +489,11 @@ impl World {
                     .add_component(component)
                     .map_err(WorldError::CouldNotAddComponent)?;
 
-                // todo(#101): make into function "add_component_to_archetype_mapping"
-                {
-                    let archetype_indices = self
-                        .component_typeid_to_archetype_indices
-                        .entry(TypeId::of::<ComponentType>())
-                        .or_default();
-                    archetype_indices.insert(target_archetype_index);
-                }
+                let archetype_indices = self
+                    .component_typeid_to_archetype_indices
+                    .entry(TypeId::of::<ComponentType>())
+                    .or_default();
+                archetype_indices.insert(target_archetype_index);
             }
         }
 

--- a/crates/ecs/src/archetypes.rs
+++ b/crates/ecs/src/archetypes.rs
@@ -448,13 +448,14 @@ impl World {
         Ok(new_archetype_index)
     }
 
-    pub(crate) fn add_component_to_entity_and_move_archetype<
-        ComponentType: Debug + Send + Sync + 'static,
-    >(
+    pub(crate) fn add_component_to_entity<ComponentType>(
         &mut self,
         entity: Entity,
         component: ComponentType,
-    ) -> WorldResult<()> {
+    ) -> WorldResult<()>
+    where
+        ComponentType: Debug + Send + Sync + 'static,
+    {
         let source_archetype_index = *self
             .entity_to_archetype_index
             .get(&entity)
@@ -514,12 +515,13 @@ impl World {
         Ok(())
     }
 
-    pub(super) fn remove_component_type_from_entity<
-        ComponentType: Debug + Send + Sync + 'static,
-    >(
+    pub(crate) fn remove_component_type_from_entity<ComponentType>(
         &mut self,
         entity: Entity,
-    ) -> WorldResult<()> {
+    ) -> WorldResult<()>
+    where
+        ComponentType: Debug + Send + Sync + 'static,
+    {
         let source_archetype_index = *self
             .entity_to_archetype_index
             .get(&entity)

--- a/crates/ecs/src/archetypes.rs
+++ b/crates/ecs/src/archetypes.rs
@@ -288,7 +288,7 @@ impl Archetype {
 }
 
 impl World {
-    pub(super) fn create_entity_in_empty_archetype(&mut self) -> WorldResult<Entity> {
+    pub(super) fn create_new_entity(&mut self) -> WorldResult<Entity> {
         if self.archetypes.is_empty() {
             // Insert the "empty entity archetype" if not already created.
             self.archetypes.push(Archetype::default());

--- a/crates/ecs/src/filter.rs
+++ b/crates/ecs/src/filter.rs
@@ -60,11 +60,7 @@ impl<Component: Debug + Send + Sync + 'static + Sized> SystemParameter for With<
         _universe: &NoHashHashSet<ArchetypeIndex>,
         world: &World,
     ) -> NoHashHashSet<ArchetypeIndex> {
-        world
-            .component_typeid_to_archetype_indices
-            .get(&TypeId::of::<Component>())
-            .cloned()
-            .unwrap_or_default()
+        world.get_archetype_indices(&[TypeId::of::<Component>()])
     }
 }
 

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -782,8 +782,8 @@ mod tests {
 
         let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
 
-        let u32_values = archetype.read_component_vec::<u32>().unwrap();
-        let i32_values = archetype.read_component_vec::<i32>().unwrap();
+        let u32_values = archetype.borrow_component_vec::<u32>().unwrap();
+        let i32_values = archetype.borrow_component_vec::<i32>().unwrap();
 
         assert_eq!(&[1_u32, 2_u32, 3_u32], &u32_values[..]);
         assert_eq!(&[1_i32, 2_i32, 3_i32], &i32_values[..]);
@@ -799,8 +799,8 @@ mod tests {
 
         let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
 
-        let u32_values = archetype.read_component_vec::<u32>().unwrap();
-        let i32_values = archetype.read_component_vec::<i32>().unwrap();
+        let u32_values = archetype.borrow_component_vec::<u32>().unwrap();
+        let i32_values = archetype.borrow_component_vec::<i32>().unwrap();
 
         assert!(u32_values.get(2).is_none());
         assert!(i32_values.get(2).is_none());
@@ -816,8 +816,8 @@ mod tests {
 
         let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
 
-        let u32_values = archetype.read_component_vec::<u32>().unwrap();
-        let i32_values = archetype.read_component_vec::<i32>().unwrap();
+        let u32_values = archetype.borrow_component_vec::<u32>().unwrap();
+        let i32_values = archetype.borrow_component_vec::<i32>().unwrap();
 
         assert_eq!(&u32_values[..2], &[3_u32, 2_u32]);
         assert_eq!(&i32_values[..2], &[3_i32, 2_i32]);
@@ -865,8 +865,8 @@ mod tests {
 
         let arch_3_i32_values = archetype_3.borrow_component_vec::<i32>().unwrap();
 
-        let arch_2_u32_values = archetype_2.read_component_vec::<u32>().unwrap();
-        let arch_2_i32_values = archetype_2.read_component_vec::<i32>().unwrap();
+        let arch_2_u32_values = archetype_2.borrow_component_vec::<u32>().unwrap();
+        let arch_2_i32_values = archetype_2.borrow_component_vec::<i32>().unwrap();
 
         assert_eq!([3_u32, 2_u32], arch_2_u32_values[..]);
         assert_eq!([3_i32, 2_i32], arch_2_i32_values[..]);
@@ -885,8 +885,8 @@ mod tests {
 
         let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
 
-        let u32_read_vec = archetype.read_component_vec::<u32>().unwrap();
-        let i32_read_vec = archetype.read_component_vec::<i32>().unwrap();
+        let u32_read_vec = archetype.borrow_component_vec::<u32>().unwrap();
+        let i32_read_vec = archetype.borrow_component_vec::<i32>().unwrap();
         let u32_values = u32_read_vec;
         let i32_values = i32_read_vec;
 
@@ -906,8 +906,8 @@ mod tests {
 
         let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
 
-        let u32_values = archetype.read_component_vec::<u32>().unwrap();
-        let i32_values = archetype.read_component_vec::<i32>().unwrap();
+        let u32_values = archetype.borrow_component_vec::<u32>().unwrap();
+        let i32_values = archetype.borrow_component_vec::<i32>().unwrap();
 
         assert_eq!(&u32_values[..2], &[3_u32, 2_u32]);
         assert_eq!(&i32_values[..2], &[3_i32, 2_i32]);

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -592,6 +592,18 @@ impl World {
             Err(_) => HashSet::default(),
         }
     }
+
+    fn get_archetype(&self, index: ArchetypeIndex) -> WorldResult<&Archetype> {
+        self.archetypes
+            .get(index)
+            .ok_or(WorldError::ArchetypeDoesNotExist(index))
+    }
+
+    fn get_archetype_mut(&mut self, index: ArchetypeIndex) -> WorldResult<&mut Archetype> {
+        self.archetypes
+            .get_mut(index)
+            .ok_or(WorldError::ArchetypeDoesNotExist(index))
+    }
 }
 
 /// Mutably borrow two *separate* elements from the given slice.
@@ -780,7 +792,7 @@ mod tests {
         let (world, relevant_archetype_index, _, _, _) =
             setup_world_with_3_entities_with_u32_and_i32_components();
 
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+        let archetype = world.get_archetype(relevant_archetype_index).unwrap();
 
         let u32_values = archetype.borrow_component_vec::<u32>().unwrap();
         let i32_values = archetype.borrow_component_vec::<i32>().unwrap();
@@ -797,7 +809,7 @@ mod tests {
         // Add component to entity1 causing it to move to Arch_3
         world.add_component_to_entity(entity1, 1_usize).unwrap();
 
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+        let archetype = world.get_archetype(relevant_archetype_index).unwrap();
 
         let u32_values = archetype.borrow_component_vec::<u32>().unwrap();
         let i32_values = archetype.borrow_component_vec::<i32>().unwrap();
@@ -814,7 +826,7 @@ mod tests {
         // Add component to entity1 causing it to move to Arch_3
         world.add_component_to_entity(entity1, 1_usize).unwrap();
 
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+        let archetype = world.get_archetype(relevant_archetype_index).unwrap();
 
         let u32_values = archetype.borrow_component_vec::<u32>().unwrap();
         let i32_values = archetype.borrow_component_vec::<i32>().unwrap();
@@ -859,9 +871,9 @@ mod tests {
             .remove_component_type_from_entity::<u32>(entity1)
             .unwrap();
 
-        let archetype_2 = world.archetypes.get(relevant_archetype_index).unwrap();
+        let archetype_2 = world.get_archetype(relevant_archetype_index).unwrap();
 
-        let archetype_3 = world.archetypes.get(3).unwrap();
+        let archetype_3 = world.get_archetype(3).unwrap();
 
         let arch_3_i32_values = archetype_3.borrow_component_vec::<i32>().unwrap();
 
@@ -883,7 +895,7 @@ mod tests {
             .remove_component_type_from_entity::<u32>(entity1)
             .unwrap();
 
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+        let archetype = world.get_archetype(relevant_archetype_index).unwrap();
 
         let u32_read_vec = archetype.borrow_component_vec::<u32>().unwrap();
         let i32_read_vec = archetype.borrow_component_vec::<i32>().unwrap();
@@ -904,7 +916,7 @@ mod tests {
             .remove_component_type_from_entity::<u32>(entity1)
             .unwrap();
 
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
+        let archetype = world.get_archetype(relevant_archetype_index).unwrap();
 
         let u32_values = archetype.borrow_component_vec::<u32>().unwrap();
         let i32_values = archetype.borrow_component_vec::<i32>().unwrap();
@@ -976,7 +988,7 @@ mod tests {
             .unwrap(); // arch_4
 
         // fetch values from arch_4
-        let archetype_4: &Archetype = world.archetypes.get(4).unwrap();
+        let archetype_4: &Archetype = world.get_archetype(4).unwrap();
 
         let component_vec_4_usize = archetype_4.borrow_component_vec::<usize>().unwrap();
         let value_usize = component_vec_4_usize.first().unwrap();

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -208,7 +208,7 @@ impl Application for BasicApplication {
         entity: Entity,
     ) -> Result<(), Self::Error> {
         self.world
-            .remove_component_from_entity::<ComponentType>(entity)
+            .remove_component_type_from_entity::<ComponentType>(entity)
             .map_err(BasicApplicationError::World)
     }
 
@@ -523,21 +523,6 @@ pub struct World {
 impl World {
     fn create_new_entity(&mut self) -> WorldResult<Entity> {
         self.create_entity_in_empty_archetype()
-    }
-
-    fn add_component_to_entity<ComponentType: Debug + Send + Sync + 'static>(
-        &mut self,
-        entity: Entity,
-        component: ComponentType,
-    ) -> WorldResult<()> {
-        self.add_component_to_entity_and_move_archetype(entity, component)
-    }
-
-    fn remove_component_from_entity<ComponentType: Debug + Send + Sync + 'static>(
-        &mut self,
-        entity: Entity,
-    ) -> WorldResult<()> {
-        self.remove_component_type_from_entity::<ComponentType>(entity)
     }
 
     fn borrow_component_vecs<ComponentType: Debug + Send + Sync + 'static>(

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -27,29 +27,25 @@
     clippy::large_enum_variant
 )]
 
+mod archetypes;
 pub mod filter;
 pub mod logging;
 pub mod profiling;
 pub mod systems;
 
+use crate::archetypes::{Archetype, ArchetypeError};
 use crate::systems::SystemError::CannotRunSequentially;
-use crate::systems::{
-    ComponentIndex, IntoSystem, System, SystemError, SystemParameters, SystemResult,
-};
+use crate::systems::{IntoSystem, System, SystemError, SystemParameters, SystemResult};
 use crate::BasicApplicationError::ScheduleGeneration;
-use core::panic;
 use crossbeam::channel::{bounded, Receiver, Sender, TryRecvError};
-use fnv::{FnvHashMap, FnvHashSet};
-use nohash_hasher::IsEnabled;
-use nohash_hasher::NoHashHasher;
-use std::any;
-use std::any::{Any, TypeId};
+use fnv::FnvHashMap;
+use nohash_hasher::{IsEnabled, NoHashHasher};
+use std::any::TypeId;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::Debug;
-use std::hash::BuildHasherDefault;
-use std::hash::Hash;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard, TryLockError};
+use std::hash::{BuildHasherDefault, Hash};
+use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 use thiserror::Error;
 
 /// Builds and configures an [`Application`] instance.
@@ -108,6 +104,19 @@ impl ApplicationBuilder for BasicApplicationBuilder {
             systems: self.systems,
         }
     }
+}
+
+fn intersection_of_multiple_sets<T: IsEnabled + Hash + Eq + Clone>(
+    sets: &[NoHashHashSet<T>],
+) -> NoHashHashSet<T> {
+    let element_overlaps_with_all_other_sets =
+        move |element: &&T| sets[1..].iter().all(|set| set.contains(element));
+    sets.get(0)
+        .unwrap_or(&HashSet::default())
+        .iter()
+        .filter(element_overlaps_with_all_other_sets)
+        .cloned()
+        .collect()
 }
 
 /// An error in the application.
@@ -199,7 +208,7 @@ impl Application for BasicApplication {
         entity: Entity,
     ) -> Result<(), Self::Error> {
         self.world
-            .remove_component_type_from_entity::<ComponentType>(entity)
+            .remove_component_from_entity::<ComponentType>(entity)
             .map_err(BasicApplicationError::World)
     }
 
@@ -438,145 +447,6 @@ impl<'systems> Schedule<'systems> for Unordered<'systems> {
     }
 }
 
-/// An error occurred during a archetype operation.
-#[derive(Error, Debug)]
-pub enum ArchetypeError {
-    /// Could not find component index of entity
-    #[error("could not find component index of entity: {0:?}")]
-    MissingEntityIndex(Entity),
-
-    /// Could not borrow component vec
-    #[error("could not borrow component vec of type: {0:?}")]
-    CouldNotBorrowComponentVec(TypeId),
-
-    /// Component vec not found for type id
-    #[error("component vec not found for type id: {0:?}")]
-    MissingComponentType(TypeId),
-
-    /// Archetype already contains entity
-    #[error("archetype already contains entity: {0:?}")]
-    EntityAlreadyExists(Entity),
-}
-
-/// Whether a archetype operation succeeded.
-pub type ArchetypeResult<T, E = ArchetypeError> = Result<T, E>;
-
-/// A hashmap where the keys are not hashed
-type NoHashHashMap<T, S> = HashMap<T, S, BuildHasherDefault<NoHashHasher<T>>>;
-
-/// A hashset where the keys are not hashed
-type NoHashHashSet<T> = HashSet<T, BuildHasherDefault<NoHashHasher<T>>>;
-
-/// Stores components associated with entity ids.
-#[derive(Debug, Default)]
-pub struct Archetype {
-    component_typeid_to_component_vec: FnvHashMap<TypeId, Box<dyn ComponentVec>>,
-    entity_to_component_index: NoHashHashMap<Entity, ComponentIndex>,
-    entity_order: Vec<Entity>,
-}
-
-/// Newly created entities with no components on them, are placed in this archetype.
-const EMPTY_ENTITY_ARCHETYPE_INDEX: ArchetypeIndex = 0;
-
-impl Archetype {
-    /// Adds an `entity_id` to keep track of and store components for.
-    ///
-    /// Returns error if entity with `id` has been stored previously.
-    fn store_entity(&mut self, entity: Entity) -> ArchetypeResult<()> {
-        let entity_index = self.entity_to_component_index.len();
-
-        match self.entity_to_component_index.insert(entity, entity_index) {
-            None => {
-                self.entity_order.push(entity);
-                Ok(())
-            }
-            Some(_) => Err(ArchetypeError::EntityAlreadyExists(entity)),
-        }
-    }
-
-    /// Returns a `ReadComponentVec` with the specified generic type `ComponentType` if it is stored.
-    fn borrow_component_vec<ComponentType: Debug + Send + Sync + 'static>(
-        &self,
-    ) -> ReadComponentVec<ComponentType> {
-        let component_typeid = TypeId::of::<ComponentType>();
-        self.component_typeid_to_component_vec
-            .get(&component_typeid)
-            .map(Box::as_ref)
-            .and_then(borrow_component_vec)
-    }
-
-    /// Returns a `WriteComponentVec` with the specified generic type `ComponentType` if it is stored.
-    fn borrow_component_vec_mut<ComponentType: Debug + Send + Sync + 'static>(
-        &self,
-    ) -> WriteComponentVec<ComponentType> {
-        let component_typeid = TypeId::of::<ComponentType>();
-        self.component_typeid_to_component_vec
-            .get(&component_typeid)
-            .map(Box::as_ref)
-            .and_then(borrow_component_vec_mut)
-    }
-
-    /// Adds a component of type `ComponentType` to archetype.
-    fn add_component<ComponentType: Debug + Send + Sync + 'static>(
-        &mut self,
-        component: ComponentType,
-    ) -> ArchetypeResult<()> {
-        let mut component_vec = self.borrow_component_vec_mut::<ComponentType>().ok_or(
-            ArchetypeError::CouldNotBorrowComponentVec(TypeId::of::<ComponentType>()),
-        )?;
-        component_vec.push(component);
-
-        Ok(())
-    }
-
-    /// Adds a component vec of type `ComponentType` if no such vec already exists.
-    ///
-    /// This function is idempotent when trying to add the same `ComponentType` multiple times.
-    fn add_component_vec<ComponentType: Debug + Send + Sync + 'static>(&mut self) {
-        if !self.contains_component_type::<ComponentType>() {
-            let raw_component_vec = create_raw_component_vec::<ComponentType>();
-
-            let component_typeid = TypeId::of::<ComponentType>();
-            self.component_typeid_to_component_vec
-                .insert(component_typeid, raw_component_vec);
-        }
-    }
-
-    /// Returns `true` if the archetype stores components of type ComponentType.
-    fn contains_component_type<ComponentType: Debug + Send + Sync + 'static>(&self) -> bool {
-        self.component_typeid_to_component_vec
-            .contains_key(&TypeId::of::<ComponentType>())
-    }
-
-    // todo(#101): make private
-    fn update_source_archetype_after_entity_move(&mut self, entity: Entity) {
-        let source_component_vec_idx = *self.entity_to_component_index.get(&entity).expect(
-            "Entity should yield a component index
-             in archetype since the the relevant archetype
-              was fetched from the entity itself.",
-        );
-        // Update old archetypes component vec index after moving entity
-        if let Some(&swapped_entity) = self.entity_order.last() {
-            self.entity_to_component_index
-                .insert(swapped_entity, source_component_vec_idx);
-        }
-        // Remove entity component index existing in its old archetype
-        self.entity_order.swap_remove(source_component_vec_idx);
-
-        self.entity_to_component_index.remove(&entity);
-    }
-    fn component_types(&self) -> FnvHashSet<TypeId> {
-        self.component_typeid_to_component_vec
-            .keys()
-            .cloned()
-            .collect()
-    }
-
-    fn get_entity(&self, component_index: ComponentIndex) -> Option<Entity> {
-        self.entity_order.get(component_index).cloned()
-    }
-}
-
 /// An error occurred during a world operation.
 #[derive(Error, Debug)]
 pub enum WorldError {
@@ -608,6 +478,15 @@ pub type WorldResult<T, E = WorldError> = Result<T, E>;
 
 /// The index of an archtype in a vec.
 type ArchetypeIndex = usize;
+
+type ReadComponentVec<'a, ComponentType> = Option<RwLockReadGuard<'a, Vec<ComponentType>>>;
+type WriteComponentVec<'a, ComponentType> = Option<RwLockWriteGuard<'a, Vec<ComponentType>>>;
+
+/// A hashmap where the keys are not hashed
+pub(crate) type NoHashHashMap<T, S> = HashMap<T, S, BuildHasherDefault<NoHashHasher<T>>>;
+
+/// A hashset where the keys are not hashed
+pub(crate) type NoHashHashSet<T> = HashSet<T, BuildHasherDefault<NoHashHasher<T>>>;
 
 /// Represents the simulated world.
 #[derive(Debug)]
@@ -641,164 +520,9 @@ pub struct World {
     component_typeids_set_to_archetype_index: FnvHashMap<Vec<TypeId>, ArchetypeIndex>,
 }
 
-type ReadComponentVec<'a, ComponentType> = Option<RwLockReadGuard<'a, Vec<ComponentType>>>;
-type WriteComponentVec<'a, ComponentType> = Option<RwLockWriteGuard<'a, Vec<ComponentType>>>;
-type TargetArchSourceTargetIDs = (
-    Option<ArchetypeIndex>,
-    FnvHashSet<TypeId>,
-    FnvHashSet<TypeId>,
-);
-enum ArchetypeMutation {
-    Removal(Entity),
-    Addition(Entity),
-}
-
 impl World {
-    /// Returns the archetype index of the archetype that contains all
-    /// components types that the entity is tied to +- the generic type
-    /// supplied to the function given Addition/ Removal enum status.
-    /// `None` is returned if no archetype containing only the sought after component types exist.
-    /// The type ids contained within the archetype the entity is existing in and the type ids for
-    /// sought archetype are also returned.
-    ///
-    /// Set mutation to ArchetypeMutation::Addition(entity)/ ArchetypeMutation::Removal(entity)
-    /// depending on if the supplied generic type should be added to or
-    /// removed from the specified entity.
-    ///
-    /// For example call world.find_target_archetype::<u32>(ArchetypeMutation::Removal(entity))
-    /// to fetch the archetype index of the archetype
-    /// containing all component types except u32 that the entity is tied to.
-    ///
-    /// world.find_target_archetype::<u32>(ArchetypeMutation::Addition(entity))
-    /// would return the archetype index of the
-    /// archetype containing all component types that the entity is tied to with the addition
-    /// of u32.
-    fn find_target_archetype<ComponentType: Debug + Send + Sync + 'static>(
-        &self,
-        mutation: ArchetypeMutation,
-    ) -> WorldResult<TargetArchSourceTargetIDs> {
-        let source_archetype_type_ids: FnvHashSet<TypeId>;
-
-        let mut target_archetype_type_ids: FnvHashSet<TypeId>;
-
-        match mutation {
-            ArchetypeMutation::Removal(nested_entity) => {
-                let source_archetype = self.get_archetype_of_entity(nested_entity)?;
-
-                source_archetype_type_ids = source_archetype.component_types();
-
-                target_archetype_type_ids = source_archetype_type_ids.clone();
-
-                if !target_archetype_type_ids.remove(&TypeId::of::<ComponentType>()) {
-                    return Err(WorldError::ComponentTypeNotPresentForEntity(
-                        nested_entity,
-                        TypeId::of::<ComponentType>(),
-                    ));
-                }
-            }
-
-            ArchetypeMutation::Addition(nested_entity) => {
-                let source_archetype = self.get_archetype_of_entity(nested_entity)?;
-
-                source_archetype_type_ids = source_archetype.component_types();
-
-                target_archetype_type_ids = source_archetype_type_ids.clone();
-
-                target_archetype_type_ids.insert(TypeId::of::<ComponentType>());
-
-                if source_archetype_type_ids.contains(&TypeId::of::<ComponentType>()) {
-                    return Err(WorldError::ComponentTypeAlreadyExistsForEntity(
-                        nested_entity,
-                        TypeId::of::<ComponentType>(),
-                    ));
-                }
-            }
-        }
-
-        let target_archetype_type_ids_vec: Vec<TypeId> = target_archetype_type_ids
-            .iter()
-            .cloned()
-            .collect::<Vec<TypeId>>();
-
-        let maybe_target_archetype =
-            self.get_exactly_matching_archetype(&target_archetype_type_ids_vec);
-
-        Ok((
-            maybe_target_archetype,
-            source_archetype_type_ids,
-            target_archetype_type_ids,
-        ))
-    }
-
-    fn move_entity_components_between_archetypes(
-        &mut self,
-        entity: Entity,
-        target_archetype_idx: ArchetypeIndex,
-        components_to_move: FnvHashSet<TypeId>,
-    ) -> WorldResult<()> {
-        let source_archetype_index = *self
-            .entity_to_archetype_index
-            .get(&entity)
-            .ok_or(WorldError::EntityDoesNotExist(entity))?;
-
-        let (source_archetype, target_archetype) = get_mut_at_two_indices(
-            source_archetype_index,
-            target_archetype_idx,
-            &mut self.archetypes,
-        );
-
-        let source_component_idx = *source_archetype
-            .entity_to_component_index
-            .get(&entity)
-            .expect("Entity should have a component index tied to it since it is already established to be existing within the archetype");
-
-        for type_id in components_to_move {
-            let source_component_vec = source_archetype
-                .component_typeid_to_component_vec
-                .get(&type_id)
-                .expect(
-                    "Type that tried to be fetched should exist
-                     in archetype since types are fetched from this archetype originally.",
-                );
-
-            source_component_vec
-                .move_element(source_component_idx, target_archetype)
-                .map_err(WorldError::CouldNotMoveComponent)?;
-        }
-
-        target_archetype
-            .store_entity(entity)
-            .map_err(WorldError::CouldNotMoveComponent)?;
-
-        self.entity_to_archetype_index
-            .insert(entity, target_archetype_idx);
-
-        Ok(())
-    }
-
-    fn move_entity_components_to_new_archetype(
-        &mut self,
-        entity: Entity,
-        components_to_move: FnvHashSet<TypeId>,
-    ) -> WorldResult<ArchetypeIndex> {
-        let new_archetype = Archetype::default();
-        let new_archetype_index: ArchetypeIndex = self.archetypes.len();
-        self.archetypes.push(new_archetype);
-
-        for component_type in &components_to_move {
-            self.component_typeid_to_archetype_indices
-                .get_mut(component_type)
-                .expect("Type ID should exist for previously existing types")
-                .insert(new_archetype_index);
-        }
-
-        self.move_entity_components_between_archetypes(
-            entity,
-            new_archetype_index,
-            components_to_move,
-        )?;
-
-        Ok(new_archetype_index)
+    fn create_new_entity(&mut self) -> WorldResult<Entity> {
+        self.create_entity_in_empty_archetype()
     }
 
     fn add_component_to_entity<ComponentType: Debug + Send + Sync + 'static>(
@@ -806,212 +530,14 @@ impl World {
         entity: Entity,
         component: ComponentType,
     ) -> WorldResult<()> {
-        let source_archetype_index = *self
-            .entity_to_archetype_index
-            .get(&entity)
-            .ok_or(WorldError::EntityDoesNotExist(entity))?;
-
-        let add = ArchetypeMutation::Addition(entity);
-
-        let (target_archetype_exists, source_type_ids, target_type_ids) =
-            self.find_target_archetype::<ComponentType>(add)?;
-
-        match target_archetype_exists {
-            Some(target_archetype_idx) => {
-                self.move_entity_components_between_archetypes(
-                    entity,
-                    target_archetype_idx,
-                    source_type_ids,
-                )?;
-
-                let target_archetype = self.archetypes
-                    .get_mut(target_archetype_idx)
-                    .expect("Archetype should exist since it was the requirement for entering this matching case");
-                target_archetype
-                    .add_component(component)
-                    .map_err(WorldError::CouldNotAddComponent)?;
-            }
-            None => {
-                let target_archetype_idx =
-                    self.move_entity_components_to_new_archetype(entity, source_type_ids)?;
-
-                let mut target_type_ids_vec: Vec<TypeId> = target_type_ids.into_iter().collect();
-
-                // Sort the vec since order of elements in vec matter when matching keys.
-                // Sorting the key is done both when inserting and reading from this hashmap to
-                // maintain consistent behaviour.
-                target_type_ids_vec.sort();
-                self.component_typeids_set_to_archetype_index
-                    .insert(target_type_ids_vec, target_archetype_idx);
-
-                let target_archetype = self
-                    .archetypes
-                    .get_mut(target_archetype_idx)
-                    .expect("This should be added in the previous function call");
-
-                // Handle incoming component
-                target_archetype.add_component_vec::<ComponentType>();
-                let archetype_indices = self
-                    .component_typeid_to_archetype_indices
-                    .entry(TypeId::of::<ComponentType>())
-                    .or_default();
-                archetype_indices.insert(target_archetype_idx);
-
-                target_archetype
-                    .add_component(component)
-                    .map_err(WorldError::CouldNotAddComponent)?;
-            }
-        }
-
-        let source_archetype = self
-            .archetypes
-            .get_mut(source_archetype_index)
-            .expect("Source archetype has already been fetched previously");
-
-        source_archetype.update_source_archetype_after_entity_move(entity);
-
-        Ok(())
+        self.add_component_to_entity_and_move_archetype(entity, component)
     }
 
-    fn remove_component_type_from_entity<ComponentType: Debug + Send + Sync + 'static>(
+    fn remove_component_from_entity<ComponentType: Debug + Send + Sync + 'static>(
         &mut self,
         entity: Entity,
     ) -> WorldResult<()> {
-        let source_archetype_index = *self
-            .entity_to_archetype_index
-            .get(&entity)
-            .ok_or(WorldError::EntityDoesNotExist(entity))?;
-
-        let removal = ArchetypeMutation::Removal(entity);
-        let (target_archetype_exists, _, target_type_ids) =
-            self.find_target_archetype::<ComponentType>(removal)?;
-
-        match target_archetype_exists {
-            Some(target_archetype_idx) => {
-                self.move_entity_components_between_archetypes(
-                    entity,
-                    target_archetype_idx,
-                    target_type_ids,
-                )?;
-            }
-            None => {
-                let mut target_type_ids_vec: Vec<TypeId> =
-                    target_type_ids.iter().cloned().collect();
-                let target_archetype_idx =
-                    self.move_entity_components_to_new_archetype(entity, target_type_ids)?;
-
-                // Sort the vec since order of elements in vec matter when matching keys.
-                // Sorting the key is done both when inserting and reading from this hashmap to
-                // maintain consistent behaviour.
-                target_type_ids_vec.sort();
-                self.component_typeids_set_to_archetype_index
-                    .insert(target_type_ids_vec, target_archetype_idx);
-            }
-        }
-
-        let source_archetype = self
-            .archetypes
-            .get_mut(source_archetype_index)
-            .ok_or(WorldError::ArchetypeDoesNotExist(source_archetype_index))?;
-
-        let source_component_vec = source_archetype
-            .component_typeid_to_component_vec
-            .get(&TypeId::of::<ComponentType>())
-            .expect(
-                "Type that tried to be fetched should exist
-                         in archetype since types are fetched from this archetype originally.",
-            );
-
-        let source_component_vec_idx = *source_archetype.entity_to_component_index
-            .get(&entity)
-            .expect("Entity should have a component index tied to it since it is already established to be existing within the archetype");
-
-        source_component_vec.remove(source_component_vec_idx);
-
-        source_archetype.update_source_archetype_after_entity_move(entity);
-
-        Ok(())
-    }
-
-    fn create_new_entity(&mut self) -> WorldResult<Entity> {
-        let entity_id = self.entities.len();
-        let entity = Entity { id: entity_id };
-        self.entities.push(entity);
-        self.store_entity_in_archetype(entity, EMPTY_ENTITY_ARCHETYPE_INDEX)?;
-        Ok(entity)
-    }
-
-    fn store_entity_in_archetype(
-        &mut self,
-        entity: Entity,
-        archetype_index: ArchetypeIndex,
-    ) -> WorldResult<()> {
-        let archetype = self
-            .archetypes
-            .get_mut(archetype_index)
-            .ok_or(WorldError::ArchetypeDoesNotExist(archetype_index))?;
-
-        archetype
-            .store_entity(entity)
-            .map_err(WorldError::CouldNotAddComponent)?;
-
-        self.entity_to_archetype_index
-            .insert(entity, archetype_index);
-        Ok(())
-    }
-
-    /// Returns the indices of all archetypes that at least contain the given signature.
-    ///
-    /// An example: if there exists the archetypes: (A), (A,B), (B,C), (A,B,C)
-    /// and the signature (A,B) is given, the indices for archetypes: (A,B) and
-    /// (A,B,C) will be returned as they both contain (A,B), while (A) only
-    /// contains A components and no B components and (B,C) only contain B and C
-    /// components and no A components.
-    fn get_archetype_indices(&self, signature: &[TypeId]) -> NoHashHashSet<ArchetypeIndex> {
-        let all_archetypes_with_signature_types: WorldResult<Vec<NoHashHashSet<ArchetypeIndex>>> =
-            signature
-                .iter()
-                .map(|component_typeid| {
-                    self.component_typeid_to_archetype_indices
-                        .get(component_typeid)
-                        .cloned()
-                        .ok_or(WorldError::ComponentTypeDoesNotExist(*component_typeid))
-                })
-                .collect();
-
-        match all_archetypes_with_signature_types {
-            Ok(archetype_indices) => intersection_of_multiple_sets(&archetype_indices),
-            Err(_) => HashSet::default(),
-        }
-    }
-
-    fn get_archetypes(&self, archetype_indices: &[ArchetypeIndex]) -> WorldResult<Vec<&Archetype>> {
-        let archetypes: Result<Vec<_>, _> = archetype_indices
-            .iter()
-            .map(|&archetype_index| {
-                self.archetypes
-                    .get(archetype_index)
-                    .ok_or(WorldError::ArchetypeDoesNotExist(archetype_index))
-            })
-            .collect();
-        archetypes
-    }
-
-    fn get_exactly_matching_archetype(
-        &self,
-        component_type_ids: &Vec<TypeId>,
-    ) -> Option<ArchetypeIndex> {
-        if component_type_ids.is_empty() {
-            return Some(EMPTY_ENTITY_ARCHETYPE_INDEX);
-        }
-        let mut sorted_component_type_ids = component_type_ids.clone();
-        // Sort the vec since order of elements in vec matter when matching keys.
-        // Sorting the key is done both when inserting and reading from this hashmap to
-        // maintain consistent behaviour.
-        sorted_component_type_ids.sort();
-        self.component_typeids_set_to_archetype_index
-            .get(&sorted_component_type_ids)
-            .copied()
+        self.remove_component_type_from_entity::<ComponentType>(entity)
     }
 
     fn borrow_component_vecs<ComponentType: Debug + Send + Sync + 'static>(
@@ -1042,18 +568,29 @@ impl World {
         Ok(component_vecs)
     }
 
-    fn get_archetype_of_entity(&self, entity: Entity) -> WorldResult<&Archetype> {
-        let source_archetype_index = *self
-            .entity_to_archetype_index
-            .get(&entity)
-            .ok_or(WorldError::EntityDoesNotExist(entity))?;
+    /// Returns the indices of all archetypes that at least contain the given signature.
+    ///
+    /// An example: if there exists the archetypes: (A), (A,B), (B,C), (A,B,C)
+    /// and the signature (A,B) is given, the indices for archetypes: (A,B) and
+    /// (A,B,C) will be returned as they both contain (A,B), while (A) only
+    /// contains A components and no B components and (B,C) only contain B and C
+    /// components and no A components.
+    fn get_archetype_indices(&self, signature: &[TypeId]) -> NoHashHashSet<ArchetypeIndex> {
+        let all_archetypes_with_signature_types: WorldResult<Vec<NoHashHashSet<ArchetypeIndex>>> =
+            signature
+                .iter()
+                .map(|component_typeid| {
+                    self.component_typeid_to_archetype_indices
+                        .get(component_typeid)
+                        .cloned()
+                        .ok_or(WorldError::ComponentTypeDoesNotExist(*component_typeid))
+                })
+                .collect();
 
-        let source_archetype = self
-            .archetypes
-            .get(source_archetype_index)
-            .ok_or(WorldError::ArchetypeDoesNotExist(source_archetype_index))?;
-
-        Ok(source_archetype)
+        match all_archetypes_with_signature_types {
+            Ok(archetype_indices) => intersection_of_multiple_sets(&archetype_indices),
+            Err(_) => HashSet::default(),
+        }
     }
 }
 
@@ -1079,14 +616,6 @@ fn get_mut_at_two_indices<T>(
     }
 }
 
-fn panic_locked_component_vec<ComponentType: 'static>() -> ! {
-    let component_type_name = any::type_name::<ComponentType>();
-    panic!(
-        "Lock of ComponentVec<{}> is already taken!",
-        component_type_name
-    )
-}
-
 impl Default for World {
     fn default() -> Self {
         Self {
@@ -1096,129 +625,6 @@ impl Default for World {
             entities: Default::default(),
             entity_to_archetype_index: Default::default(),
         }
-    }
-}
-
-fn create_raw_component_vec<ComponentType: Debug + Send + Sync + 'static>() -> Box<dyn ComponentVec>
-{
-    Box::<ComponentVecImpl<ComponentType>>::default()
-}
-
-fn borrow_component_vec<ComponentType: 'static>(
-    component_vec: &dyn ComponentVec,
-) -> ReadComponentVec<ComponentType> {
-    if let Some(component_vec) = component_vec
-        .as_any()
-        .downcast_ref::<ComponentVecImpl<ComponentType>>()
-    {
-        // This method should only be called once the scheduler has verified
-        // that component access can be done without contention.
-        // Panicking helps us detect errors in the scheduling algorithm more quickly.
-        return match component_vec.try_read() {
-            Ok(component_vec) => Some(component_vec),
-            Err(TryLockError::WouldBlock) => panic_locked_component_vec::<ComponentType>(),
-            Err(TryLockError::Poisoned(_)) => panic!("Lock should not be poisoned!"),
-        };
-    }
-    None
-}
-
-fn borrow_component_vec_mut<ComponentType: 'static>(
-    component_vec: &dyn ComponentVec,
-) -> WriteComponentVec<ComponentType> {
-    if let Some(component_vec) = component_vec
-        .as_any()
-        .downcast_ref::<ComponentVecImpl<ComponentType>>()
-    {
-        // This method should only be called once the scheduler has verified
-        // that component access can be done without contention.
-        // Panicking helps us detect errors in the scheduling algorithm more quickly.
-        return match component_vec.try_write() {
-            Ok(component_vec) => Some(component_vec),
-            Err(TryLockError::WouldBlock) => panic_locked_component_vec::<ComponentType>(),
-            Err(TryLockError::Poisoned(_)) => panic!("Lock should not be poisoned!"),
-        };
-    }
-    None
-}
-
-fn intersection_of_multiple_sets<T: IsEnabled + Hash + Eq + Clone>(
-    sets: &[NoHashHashSet<T>],
-) -> NoHashHashSet<T> {
-    let element_overlaps_with_all_other_sets =
-        move |element: &&T| sets[1..].iter().all(|set| set.contains(element));
-    sets.get(0)
-        .unwrap_or(&HashSet::default())
-        .iter()
-        .filter(element_overlaps_with_all_other_sets)
-        .cloned()
-        .collect()
-}
-
-type ComponentVecImpl<ComponentType> = RwLock<Vec<ComponentType>>;
-
-trait ComponentVec: Debug + Send + Sync {
-    fn as_any(&self) -> &dyn Any;
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-    /// Returns the type stored in the component vector.
-    fn stored_type(&self) -> TypeId;
-    /// Returns the number of components stored in the component vector.
-    fn len(&self) -> usize;
-    /// Removes the entity from the component vector.
-    fn remove(&self, index: usize);
-    /// Removes a component and pushes it to another
-    /// archetypes component vector of the same data type.
-    fn move_element(&self, source_index: usize, target_arch: &mut Archetype)
-        -> ArchetypeResult<()>;
-}
-
-impl<T: Debug + Send + Sync + 'static> ComponentVec for ComponentVecImpl<T> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn stored_type(&self) -> TypeId {
-        TypeId::of::<T>()
-    }
-
-    fn len(&self) -> usize {
-        Vec::len(&self.read().expect("Lock is poisoned"))
-    }
-
-    fn remove(&self, index: usize) {
-        self.write().expect("Lock is poisoned").swap_remove(index);
-    }
-
-    fn move_element(
-        &self,
-        source_index: usize,
-        target_arch: &mut Archetype,
-    ) -> ArchetypeResult<()> {
-        let value = self
-            .write()
-            .expect("Lock is poisoned")
-            .swap_remove(source_index);
-
-        if !target_arch.contains_component_type::<T>() {
-            target_arch.add_component_vec::<T>()
-        }
-
-        let target_vec = target_arch
-            .component_typeid_to_component_vec
-            .get(&TypeId::of::<T>())
-            .expect("component vec has been added if it was not there previously")
-            .as_ref();
-
-        let mut component_vec = borrow_component_vec_mut::<T>(target_vec)
-            .ok_or(ArchetypeError::CouldNotBorrowComponentVec(TypeId::of::<T>()))?;
-
-        component_vec.push(value);
-
-        Ok(())
     }
 }
 
@@ -1239,8 +645,8 @@ impl IsEnabled for Entity {}
 
 #[cfg(test)]
 mod tests {
-    use super::systems::*;
     use super::*;
+    use crate::systems::{Read, SystemParameter};
     use test_case::test_case;
     use test_log::test;
 
@@ -1253,98 +659,30 @@ mod tests {
     #[derive(Debug)]
     struct C;
 
-    trait BorrowComponentVecsWithSignature {
-        fn borrow_component_vecs_with_signature<ComponentType: Debug + Send + Sync + 'static>(
-            &self,
-            signature: &[TypeId],
-        ) -> WorldResult<Vec<ReadComponentVec<ComponentType>>>;
-
-        fn borrow_component_vecs_with_signature_mut<ComponentType: Debug + Send + Sync + 'static>(
-            &self,
-            signature: &[TypeId],
-        ) -> WorldResult<Vec<WriteComponentVec<ComponentType>>>;
-    }
-
-    impl BorrowComponentVecsWithSignature for World {
-        fn borrow_component_vecs_with_signature<ComponentType: Debug + Send + Sync + 'static>(
-            &self,
-            signature: &[TypeId],
-        ) -> WorldResult<Vec<ReadComponentVec<ComponentType>>> {
-            let archetype_indices: Vec<_> =
-                self.get_archetype_indices(signature).into_iter().collect();
-            self.borrow_component_vecs(&archetype_indices)
-        }
-
-        fn borrow_component_vecs_with_signature_mut<
-            ComponentType: Debug + Send + Sync + 'static,
-        >(
-            &self,
-            signature: &[TypeId],
-        ) -> WorldResult<Vec<WriteComponentVec<ComponentType>>> {
-            let archetype_indices: Vec<_> =
-                self.get_archetype_indices(signature).into_iter().collect();
-            self.borrow_component_vecs_mut(&archetype_indices)
-        }
-    }
-
     #[test]
-    #[should_panic(expected = "Lock of ComponentVec<ecs::tests::A> is already taken!")]
-    fn world_panics_when_trying_to_mutably_borrow_same_components_twice() {
-        let mut world = World::default();
-
-        let entity = world.create_new_entity().unwrap();
-        world.add_component_to_entity(entity, A).unwrap();
-
-        let _first = world
-            .borrow_component_vecs_with_signature_mut::<A>(&[TypeId::of::<A>()])
-            .unwrap();
-        let _second = world
-            .borrow_component_vecs_with_signature_mut::<A>(&[TypeId::of::<A>()])
-            .unwrap();
-    }
-
-    #[test]
-    fn world_doesnt_panic_when_mutably_borrowing_components_after_dropping_previous_mutable_borrow()
-    {
-        let mut world = World::default();
-
-        let entity = world.create_new_entity().unwrap();
-
-        world.add_component_to_entity(entity, A).unwrap();
-
-        let first = world.borrow_component_vecs_with_signature_mut::<A>(&[TypeId::of::<A>()]);
-        drop(first);
-        let _second = world.borrow_component_vecs_with_signature_mut::<A>(&[TypeId::of::<A>()]);
-    }
-
-    #[test]
-    fn world_does_not_panic_when_trying_to_immutably_borrow_same_components_twice() {
-        let mut world = World::default();
-
-        let entity = world.create_new_entity().unwrap();
-
-        world.add_component_to_entity(entity, A).unwrap();
-
-        let _first = world.borrow_component_vecs_with_signature::<A>(&[TypeId::of::<A>()]);
-        let _second = world.borrow_component_vecs_with_signature::<A>(&[TypeId::of::<A>()]);
-    }
-
-    // Archetype tests:
-
-    #[test]
-    fn type_id_order_does_not_affect_fetching_of_correct_archetype() {
+    fn querying_with_archetypes() {
+        // Arrange
         let (world, _, _, _, _) = setup_world_with_3_entities_with_u32_and_i32_components();
 
-        let type_vector_1 = vec![TypeId::of::<u32>(), TypeId::of::<i32>()];
-        let type_vector_2 = vec![TypeId::of::<i32>(), TypeId::of::<u32>()];
-        let result_1 = world
-            .get_exactly_matching_archetype(&type_vector_1)
-            .unwrap();
-        let result_2 = world
-            .get_exactly_matching_archetype(&type_vector_2)
-            .unwrap();
+        let mut result: HashSet<u32> = HashSet::new();
 
-        assert_eq!(result_1, result_2);
+        let archetypes: Vec<ArchetypeIndex> = world
+            .get_archetype_indices(&[TypeId::of::<u32>()])
+            .into_iter()
+            .collect();
+
+        let mut borrowed = <Read<u32> as SystemParameter>::borrow(&world, &archetypes).unwrap();
+
+        // SAFETY: This is safe because the result from fetch_parameter will not outlive borrowed
+        unsafe {
+            while let Some(parameter) =
+                <Read<u32> as SystemParameter>::fetch_parameter(&mut borrowed)
+            {
+                result.insert(*parameter);
+            }
+        }
+
+        assert_eq!(result, HashSet::from([1, 2, 3]))
     }
 
     #[test]
@@ -1417,49 +755,24 @@ mod tests {
     }
 
     fn setup_world_with_3_entities_with_u32_and_i32_components(
-    ) -> (World, usize, Entity, Entity, Entity) {
+    ) -> (World, ArchetypeIndex, Entity, Entity, Entity) {
         let mut world = World::default();
 
         let entity1 = world.create_new_entity().unwrap();
         let entity2 = world.create_new_entity().unwrap();
         let entity3 = world.create_new_entity().unwrap();
 
-        world.add_component_to_entity(entity1, 1_u32).unwrap();
-        world.add_component_to_entity(entity1, 1_i32).unwrap();
+        world.add_component_to_entity::<u32>(entity1, 1).unwrap();
+        world.add_component_to_entity::<i32>(entity1, 1).unwrap();
 
-        world.add_component_to_entity(entity2, 2_u32).unwrap();
-        world.add_component_to_entity(entity2, 2_i32).unwrap();
+        world.add_component_to_entity::<u32>(entity2, 2).unwrap();
+        world.add_component_to_entity::<i32>(entity2, 2).unwrap();
 
-        world.add_component_to_entity(entity3, 3_u32).unwrap();
-        world.add_component_to_entity(entity3, 3_i32).unwrap();
+        world.add_component_to_entity::<u32>(entity3, 3).unwrap();
+        world.add_component_to_entity::<i32>(entity3, 3).unwrap();
 
         // All entities in archetype with index 2 now
         (world, 2, entity1, entity2, entity3)
-    }
-
-    type UnwrappedReadComponentVec<'a, ComponentType> = RwLockReadGuard<'a, Vec<ComponentType>>;
-
-    fn get_u32_and_i32_component_vectors(
-        archetype: &Archetype,
-    ) -> (
-        UnwrappedReadComponentVec<u32>,
-        UnwrappedReadComponentVec<i32>,
-    ) {
-        let component_vec_u32 = archetype
-            .component_typeid_to_component_vec
-            .get(&TypeId::of::<u32>())
-            .unwrap()
-            .as_ref();
-        let u32_read_vec = borrow_component_vec::<u32>(component_vec_u32);
-
-        let component_vec_i32 = archetype
-            .component_typeid_to_component_vec
-            .get(&TypeId::of::<i32>())
-            .unwrap()
-            .as_ref();
-        let i32_read_vec = borrow_component_vec::<i32>(component_vec_i32);
-
-        (u32_read_vec.unwrap(), i32_read_vec.unwrap())
     }
 
     #[test]
@@ -1469,38 +782,11 @@ mod tests {
 
         let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
 
-        let (u32_read_vec, i32_read_vec) = get_u32_and_i32_component_vectors(archetype);
-        let u32_values = u32_read_vec;
-        let i32_values = i32_read_vec;
+        let u32_values = archetype.read_component_vec::<u32>().unwrap();
+        let i32_values = archetype.read_component_vec::<i32>().unwrap();
 
         assert_eq!(&[1_u32, 2_u32, 3_u32], &u32_values[..]);
         assert_eq!(&[1_i32, 2_i32, 3_i32], &i32_values[..]);
-    }
-
-    #[test]
-    fn entities_are_in_expected_order_according_to_when_components_were_added() {
-        let (world, relevant_archetype_index, entity1, entity2, entity3) =
-            setup_world_with_3_entities_with_u32_and_i32_components();
-
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
-
-        assert_eq!(archetype.entity_order, vec![entity1, entity2, entity3]);
-    }
-
-    #[test]
-    fn entity_to_component_index_gives_expected_values_after_addition() {
-        let (world, relevant_archetype_index, entity1, entity2, entity3) =
-            setup_world_with_3_entities_with_u32_and_i32_components();
-
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
-
-        let entity1_component_index = *archetype.entity_to_component_index.get(&entity1).unwrap();
-        let entity2_component_index = *archetype.entity_to_component_index.get(&entity2).unwrap();
-        let entity3_component_index = *archetype.entity_to_component_index.get(&entity3).unwrap();
-
-        assert_eq!(entity1_component_index, 0);
-        assert_eq!(entity2_component_index, 1);
-        assert_eq!(entity3_component_index, 2);
     }
 
     #[test]
@@ -1513,9 +799,8 @@ mod tests {
 
         let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
 
-        let (u32_read_vec, i32_read_vec) = get_u32_and_i32_component_vectors(archetype);
-        let u32_values = u32_read_vec;
-        let i32_values = i32_read_vec;
+        let u32_values = archetype.read_component_vec::<u32>().unwrap();
+        let i32_values = archetype.read_component_vec::<i32>().unwrap();
 
         assert!(u32_values.get(2).is_none());
         assert!(i32_values.get(2).is_none());
@@ -1531,43 +816,11 @@ mod tests {
 
         let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
 
-        let (u32_read_vec, i32_read_vec) = get_u32_and_i32_component_vectors(archetype);
-        let u32_values = u32_read_vec;
-        let i32_values = i32_read_vec;
+        let u32_values = archetype.read_component_vec::<u32>().unwrap();
+        let i32_values = archetype.read_component_vec::<i32>().unwrap();
 
         assert_eq!(&u32_values[..2], &[3_u32, 2_u32]);
         assert_eq!(&i32_values[..2], &[3_i32, 2_i32]);
-    }
-
-    #[test]
-    fn entity_order_swap_index_after_entity_has_been_moved_by_addition() {
-        let (mut world, relevant_archetype_index, entity1, entity2, entity3) =
-            setup_world_with_3_entities_with_u32_and_i32_components();
-
-        // Add component to entity1 causing it to move to Arch_3
-        world.add_component_to_entity(entity1, 1_usize).unwrap();
-
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
-
-        assert_eq!(archetype.entity_order, vec![entity3, entity2]);
-    }
-
-    #[test]
-    fn entity_to_component_index_is_updated_after_move_by_addition() {
-        let (mut world, relevant_archetype_index, entity1, entity2, entity3) =
-            setup_world_with_3_entities_with_u32_and_i32_components();
-
-        // Add component to entity1 causing it to move to Arch_3
-        world.add_component_to_entity(entity1, 1_usize).unwrap();
-
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
-
-        let entity1_component_index = archetype.entity_to_component_index.get(&entity1);
-        let entity2_component_index = archetype.entity_to_component_index.get(&entity2);
-        let entity3_component_index = archetype.entity_to_component_index.get(&entity3);
-        assert!(entity1_component_index.is_none());
-        assert_eq!(entity2_component_index, Some(&1));
-        assert_eq!(entity3_component_index, Some(&0));
     }
 
     #[test]
@@ -1612,38 +865,12 @@ mod tests {
 
         let arch_3_i32_values = archetype_3.borrow_component_vec::<i32>().unwrap();
 
-        let (u32_read_vec, i32_read_vec) = get_u32_and_i32_component_vectors(archetype_2);
-        let arch_2_u32_values = u32_read_vec;
-        let arch_2_i32_values = i32_read_vec;
+        let arch_2_u32_values = archetype_2.read_component_vec::<u32>().unwrap();
+        let arch_2_i32_values = archetype_2.read_component_vec::<i32>().unwrap();
 
         assert_eq!([3_u32, 2_u32], arch_2_u32_values[..]);
         assert_eq!([3_i32, 2_i32], arch_2_i32_values[..]);
         assert_eq!([1_i32], arch_3_i32_values[..]);
-    }
-
-    #[test]
-    fn entity_to_component_index_gives_expected_values_after_removal() {
-        let (mut world, relevant_archetype_index, entity1, entity2, entity3) =
-            setup_world_with_3_entities_with_u32_and_i32_components();
-
-        // Add component to entity1 causing it to move to Arch_3
-        world
-            .remove_component_type_from_entity::<u32>(entity1)
-            .unwrap();
-
-        let archetype_1 = world.archetypes.get(3).unwrap();
-        let archetype_2 = world.archetypes.get(relevant_archetype_index).unwrap();
-
-        let arch_1_entity1_component_index = archetype_1.entity_to_component_index.get(&entity1);
-
-        let arch_2_entity1_component_index = archetype_2.entity_to_component_index.get(&entity1);
-        let arch_2_entity2_component_index = archetype_2.entity_to_component_index.get(&entity2);
-        let arch_2_entity3_component_index = archetype_2.entity_to_component_index.get(&entity3);
-
-        assert_eq!(arch_1_entity1_component_index, Some(&0));
-        assert_eq!(arch_2_entity1_component_index, None);
-        assert_eq!(arch_2_entity2_component_index, Some(&1));
-        assert_eq!(arch_2_entity3_component_index, Some(&0));
     }
 
     #[test]
@@ -1658,7 +885,8 @@ mod tests {
 
         let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
 
-        let (u32_read_vec, i32_read_vec) = get_u32_and_i32_component_vectors(archetype);
+        let u32_read_vec = archetype.read_component_vec::<u32>().unwrap();
+        let i32_read_vec = archetype.read_component_vec::<i32>().unwrap();
         let u32_values = u32_read_vec;
         let i32_values = i32_read_vec;
 
@@ -1678,47 +906,11 @@ mod tests {
 
         let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
 
-        let (u32_read_vec, i32_read_vec) = get_u32_and_i32_component_vectors(archetype);
-        let u32_values = u32_read_vec;
-        let i32_values = i32_read_vec;
+        let u32_values = archetype.read_component_vec::<u32>().unwrap();
+        let i32_values = archetype.read_component_vec::<i32>().unwrap();
 
         assert_eq!(&u32_values[..2], &[3_u32, 2_u32]);
         assert_eq!(&i32_values[..2], &[3_i32, 2_i32]);
-    }
-
-    #[test]
-    fn entity_order_swap_index_after_entity_has_been_moved_by_removal() {
-        let (mut world, relevant_archetype_index, entity1, entity2, entity3) =
-            setup_world_with_3_entities_with_u32_and_i32_components();
-
-        // Add component to entity1 causing it to move to Arch_3
-        world
-            .remove_component_type_from_entity::<u32>(entity1)
-            .unwrap();
-
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
-
-        assert_eq!(archetype.entity_order, vec![entity3, entity2]);
-    }
-
-    #[test]
-    fn entity_to_component_index_is_updated_after_move_by_removal() {
-        let (mut world, relevant_archetype_index, entity1, entity2, entity3) =
-            setup_world_with_3_entities_with_u32_and_i32_components();
-
-        // Add component to entity1 causing it to move to Arch_3
-        world
-            .remove_component_type_from_entity::<u32>(entity1)
-            .unwrap();
-
-        let archetype = world.archetypes.get(relevant_archetype_index).unwrap();
-
-        let entity1_component_index = archetype.entity_to_component_index.get(&entity1);
-        let entity2_component_index = archetype.entity_to_component_index.get(&entity2);
-        let entity3_component_index = archetype.entity_to_component_index.get(&entity3);
-        assert!(entity1_component_index.is_none());
-        assert_eq!(entity2_component_index, Some(&1));
-        assert_eq!(entity3_component_index, Some(&0));
     }
 
     #[test]
@@ -1796,135 +988,6 @@ mod tests {
         assert_eq!(*value_i64, 321);
     }
 
-    fn setup_world_with_three_entities_and_components() -> World {
-        // Arrange
-        let mut world = World::default();
-
-        let entity1 = world.create_new_entity().unwrap();
-        let entity2 = world.create_new_entity().unwrap();
-        let entity3 = world.create_new_entity().unwrap();
-
-        // insert some components...
-        world.add_component_to_entity::<u64>(entity1, 1).unwrap();
-        world.add_component_to_entity::<u32>(entity1, 2).unwrap();
-
-        world.add_component_to_entity::<u64>(entity2, 3).unwrap();
-        world.add_component_to_entity::<u32>(entity2, 4).unwrap();
-
-        world.add_component_to_entity::<u32>(entity3, 6).unwrap();
-
-        world
-    }
-
-    #[test]
-    fn borrow_with_signature_returns_expected_values() {
-        // Arrange
-        let world = setup_world_with_three_entities_and_components();
-
-        // Act
-        // Borrow all vecs containing u32 from archetypes have the signature u32
-        let vecs_u32 = world
-            .borrow_component_vecs_with_signature::<u32>(&[TypeId::of::<u32>()])
-            .unwrap();
-        eprintln!("vecs_u32 = {vecs_u32:#?}");
-        // Assert
-        // Collect values from vecs
-        let result: HashSet<u32> = vecs_u32
-            .iter()
-            .flat_map(|component_vec| component_vec.as_ref().unwrap().iter().copied())
-            .collect();
-        println!("{result:?}");
-
-        assert_eq!(result, HashSet::from([2, 4, 6]))
-    }
-
-    #[test]
-    fn borrowing_non_existent_component_returns_empty_vec() {
-        // Arrange
-        let world = setup_world_with_three_entities_and_components();
-
-        // Act
-        let vecs_f32 = world
-            .borrow_component_vecs_with_signature::<f32>(&[TypeId::of::<f32>()])
-            .unwrap();
-        eprintln!("vecs_f32 = {vecs_f32:#?}");
-        // Assert
-        // Collect values from vecs
-        let result: Vec<f32> = vecs_f32
-            .iter()
-            .flat_map(|component_vec| component_vec.as_ref().unwrap().iter().copied())
-            .collect();
-        println!("{result:?}");
-
-        assert_eq!(result, vec![])
-    }
-
-    #[test]
-    fn querying_with_archetypes() {
-        // Arrange
-        let world = setup_world_with_three_entities_and_components();
-
-        let mut result: HashSet<u32> = HashSet::new();
-
-        let archetypes: Vec<ArchetypeIndex> = world
-            .get_archetype_indices(&[TypeId::of::<u32>()])
-            .into_iter()
-            .collect();
-
-        let mut borrowed = <Read<u32> as SystemParameter>::borrow(&world, &archetypes).unwrap();
-
-        // SAFETY: This is safe because the result from fetch_parameter will not outlive borrowed
-        unsafe {
-            while let Some(parameter) =
-                <Read<u32> as SystemParameter>::fetch_parameter(&mut borrowed)
-            {
-                result.insert(*parameter);
-            }
-        }
-
-        assert_eq!(result, HashSet::from([2, 4, 6]))
-    }
-
-    #[test]
-    #[should_panic]
-    fn borrowing_component_vec_twice_from_archetype_causes_panic() {
-        let mut archetype = Archetype::default();
-        archetype.add_component_vec::<u32>();
-
-        let borrow_1 = archetype.borrow_component_vec_mut::<u32>();
-        let borrow_2 = archetype.borrow_component_vec_mut::<u32>();
-
-        // Drop after both have been borrowed to make sure they both live this long.
-        drop(borrow_1);
-        drop(borrow_2);
-    }
-
-    #[test]
-    fn borrowing_component_vec_after_reference_has_been_dropped_does_not_cause_panic() {
-        let mut archetype = Archetype::default();
-        archetype.add_component_vec::<u32>();
-
-        let borrow_1 = archetype.borrow_component_vec_mut::<u32>();
-        drop(borrow_1);
-
-        let borrow_2 = archetype.borrow_component_vec_mut::<u32>();
-        drop(borrow_2);
-    }
-
-    #[test]
-    fn borrowing_two_different_component_vecs_from_archetype_does_not_cause_panic() {
-        let mut archetype = Archetype::default();
-        archetype.add_component_vec::<u32>();
-        archetype.add_component_vec::<u64>();
-
-        let a = archetype.borrow_component_vec_mut::<u32>();
-        let b = archetype.borrow_component_vec_mut::<u64>();
-
-        // Drop after both have been borrowed to make sure they both live this long.
-        drop(a);
-        drop(b);
-    }
-
     // Intersection tests:
     #[test_case(vec![vec![1,2,3]], vec![1,2,3]; "self intersection")]
     #[test_case(vec![vec![1,2,3], vec![1,2,3]], vec![1,2,3]; "two of the same")]
@@ -1952,21 +1015,5 @@ mod tests {
 
         // Assert intersection result equals expected value
         assert_eq!(result, borrowed_expected_value);
-    }
-
-    #[test]
-    fn get_entity_from_component_index() {
-        let world = setup_world_with_three_entities_and_components();
-
-        //Get the first entity added to world
-        let comp_entity = world.entities.get(0).copied().unwrap();
-
-        //Get the archetype index of the archetype that stores that entity
-        let archetype = world.get_archetype_of_entity(comp_entity).unwrap();
-
-        //Get the first entity stored in that archetype, check that it is the same
-        let get_entity = archetype.get_entity(0).unwrap();
-
-        assert_eq!(comp_entity, get_entity);
     }
 }

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -489,7 +489,7 @@ pub(crate) type NoHashHashMap<T, S> = HashMap<T, S, BuildHasherDefault<NoHashHas
 pub(crate) type NoHashHashSet<T> = HashSet<T, BuildHasherDefault<NoHashHasher<T>>>;
 
 /// Represents the simulated world.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct World {
     entities: Vec<Entity>,
     /// Relates a unique `Entity Id` to the `Archetype` that stores it.
@@ -625,18 +625,6 @@ fn get_mut_at_two_indices<T>(
         (&mut first_slice[first_index], &mut second_slice[0])
     } else {
         (&mut second_slice[0], &mut first_slice[second_index])
-    }
-}
-
-impl Default for World {
-    fn default() -> Self {
-        Self {
-            archetypes: vec![Archetype::default()],
-            component_typeid_to_archetype_indices: Default::default(),
-            component_typeids_set_to_archetype_index: Default::default(),
-            entities: Default::default(),
-            entity_to_archetype_index: Default::default(),
-        }
     }
 }
 

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -521,10 +521,6 @@ pub struct World {
 }
 
 impl World {
-    fn create_new_entity(&mut self) -> WorldResult<Entity> {
-        self.create_entity_in_empty_archetype()
-    }
-
     fn borrow_component_vecs<ComponentType: Debug + Send + Sync + 'static>(
         &self,
         archetype_indices: &[ArchetypeIndex],

--- a/crates/ecs/src/systems/mod.rs
+++ b/crates/ecs/src/systems/mod.rs
@@ -5,8 +5,8 @@ pub mod iteration;
 
 use crate::systems::iteration::{SegmentIterable, SequentiallyIterable};
 use crate::{
-    intersection_of_multiple_sets, Archetype, ArchetypeIndex, Entity, NoHashHashSet, ReadComponentVec, World,
-    WorldError, WriteComponentVec,
+    intersection_of_multiple_sets, Archetype, ArchetypeIndex, Entity, NoHashHashSet,
+    ReadComponentVec, World, WorldError, WriteComponentVec,
 };
 use paste::paste;
 use std::any::TypeId;
@@ -663,12 +663,12 @@ macro_rules! impl_system_parameter_function {
                 pub fn get_entity(&self, entity: Entity) -> Option<($([<P$parameter>],)*)> {
                     let archetype_index = self.world.entity_to_archetype_index.get(&entity)?;
                     let archetype = self.world.archetypes.get(*archetype_index)?;
-                    let component_index = archetype.entity_to_component_index.get(&entity)?;
+                    let component_index = archetype.get_component_index_of(entity)?;
 
                     $(let mut [<borrowed_$parameter>] = [<P$parameter>]::borrow(self.world, &[*archetype_index])
                         .expect("`borrow` should work if the archetypes are in a valid state");)*
 
-                    $([<P$parameter>]::set_archetype_and_component_index(&mut [<borrowed_$parameter>], 0, *component_index);)*
+                    $([<P$parameter>]::set_archetype_and_component_index(&mut [<borrowed_$parameter>], 0, component_index);)*
 
                     // SAFETY:
                     // In this situation, borrowed cannot be guaranteed to outlive the result from


### PR DESCRIPTION
Factors out most of the archetypes-code into its own separate module. This is the first step of implementing #53.

I've also simplified a few function calls and aggregated some duplicate functionality.

> Note to reviewers: Since this is almost entirely just a refactor, you don't need to focus on reviewing the hundreds of lines of code. Instead, focus on the structure, visibility of functions and structs and general division of responsibility. 
>
> The non-refactoring changes I've made are encapsulated in the following commits, and should be reviewed as usual: 458ca0c526229bbbe4cf450e7aadd91374688c6c, 922dc2fb857b100f3f9b5df5a56645a5eaa5329f, eed842dc8b5ac7e383e2f895326b67d25b376694, 1465c406b8b60c4dfddf780fd4f64737287fde4b and 7764169a4a546d186ef7e9a3f3a220f915057bc9.

Closes #101 